### PR TITLE
Revamp header navigation and hero ASCII logo

### DIFF
--- a/about.php
+++ b/about.php
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>About SkuzE</h2>
   <p>SkuzE provides repair, modding, and custom build services for your electronics.</p>

--- a/assets/sidebar.js
+++ b/assets/sidebar.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.querySelector('.side-nav-toggle');
+  const sideNav = document.querySelector('.side-nav');
+  if (toggle && sideNav) {
+    toggle.addEventListener('click', () => {
+      sideNav.classList.toggle('open');
+    });
+  }
+});

--- a/assets/style.css
+++ b/assets/style.css
@@ -60,10 +60,13 @@ body {
 }
 
 
-.hero .hero-logo {
-  max-width: 300px;
-  width: 100%;
-  height: auto;
+
+.hero-ascii {
+  font-family: monospace;
+  font-size: clamp(1rem, 4vw, 2rem);
+  line-height: 1;
+  text-align: center;
+  margin: 0;
 }
 
 .cta-buttons {
@@ -167,6 +170,12 @@ footer {
   padding: 1rem 0;
 }
 
+.logo-img {
+  max-width: 100px;
+  width: 100%;
+  height: auto;
+}
+
 .site-nav ul {
   display: flex;
   gap: 1rem;
@@ -175,19 +184,6 @@ footer {
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.site-nav .nav-button {
-  background: var(--accent);
-  color: #fff;
-  text-decoration: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  display: inline-block;
-}
-
-.site-nav .nav-button:hover {
-  opacity: 0.9;
 }
 
 /* Forms and buttons */
@@ -355,4 +351,50 @@ tbody tr:nth-child(even) {
   margin: 0 0.5rem;
   color: var(--accent);
   text-decoration: none;
+}
+
+/* Side navigation */
+.side-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 200px;
+  background: var(--bg);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 1000;
+  padding-top: 2rem;
+}
+
+.side-nav.open {
+  transform: translateX(0);
+}
+
+.side-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.side-nav li {
+  margin: 1rem;
+}
+
+.side-nav a {
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.side-nav-toggle {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.5rem;
+  cursor: pointer;
+  z-index: 1001;
 }

--- a/buy-step.php
+++ b/buy-step.php
@@ -16,6 +16,7 @@ function label($text, $name, $type = 'text', $required = true) {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <?php if ($category === ''): ?>
     <h2>Request a Device</h2>

--- a/buy.php
+++ b/buy.php
@@ -56,6 +56,7 @@ $stmt->close();
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Available Listings</h2>
   <div class="content">

--- a/cancel.php
+++ b/cancel.php
@@ -8,6 +8,7 @@ require 'includes/auth.php';
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Payment Canceled</h2>
   <p>Your payment was canceled. No charges were made.</p>

--- a/dashboard.php
+++ b/dashboard.php
@@ -25,6 +25,7 @@ if ($stmt === false) {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
 
   <h2>Welcome, <?= htmlspecialchars($username) ?></h2>

--- a/followers.php
+++ b/followers.php
@@ -37,6 +37,7 @@ if ($stmt) {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Your Followers</h2>
   <ul>

--- a/forgot.php
+++ b/forgot.php
@@ -66,6 +66,7 @@ require 'mail.php';
 <html>
 <head><title>Forgot Password</title></head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Forgot Password</h2>
   <?php if (!empty($msg)) echo "<p>" . htmlspecialchars($msg) . "</p>"; ?>

--- a/friend-requests.php
+++ b/friend-requests.php
@@ -56,6 +56,7 @@ if ($stmt) {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Friend Requests</h2>
   <?php if (!empty($error)) echo "<p style='color:red;'>" . htmlspecialchars($error) . "</p>"; ?>

--- a/friend-search.php
+++ b/friend-search.php
@@ -53,6 +53,7 @@ if ($query !== '') {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Find Friends</h2>
   <?php if (!empty($error)) echo "<p style='color:red;'>" . htmlspecialchars($error) . "</p>"; ?>

--- a/help.php
+++ b/help.php
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Help & FAQ</h2>
   <p>Find answers to common questions and tips for locating your device's IMEI or serial number.</p>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,3 +1,4 @@
 <footer>
   <p>&copy; <?= date('Y') ?> SkuzE. All rights reserved. | <a href="/about.php">About</a></p>
 </footer>
+<script src="assets/sidebar.js"></script>

--- a/includes/header.php
+++ b/includes/header.php
@@ -48,34 +48,18 @@ if (file_exists($settingsFile)) {
 </style>
 <header class="site-header">
   <a href="/index.php" class="logo-link">
-    <img src="/assets/logo.png" alt="SkuzE Logo">
+    <img class="logo-img" src="/assets/logo.png" alt="SkuzE Logo">
   </a>
   <nav class="site-nav">
     <ul>
-      <li><a class="nav-button" href="/services.php">Services</a></li>
-      <li><a class="nav-button" href="/buy.php">Buy</a></li>
-      <li><a class="nav-button" href="/sell.php">Sell</a></li>
-      <li><a class="nav-button" href="/trade.php">Trade</a></li>
-      <li><a class="nav-button" href="/forum/index.php">Forum</a></li>
+      <li><a href="/index.php">Home</a></li>
+      <li><a href="/about.php">About</a></li>
 <?php if (empty($_SESSION['user_id'])): ?>
-      <li><a class="nav-button" href="/login.php">Login</a></li>
-      <li><a class="nav-button" href="/register.php">Register</a></li>
+      <li><a href="/login.php">Login</a></li>
+      <li><a href="/register.php">Register</a></li>
 <?php else: ?>
-      <li class="nav-username">Hello, <?= username_with_avatar(
-        $conn,
-        $_SESSION['user_id'],
-        $username
-      ); ?></li>
-      <li class="nav-status">Status: <?= htmlspecialchars(
-        $status,
-        ENT_QUOTES,
-        'UTF-8'
-      ) ?></li>
-      <li><a class="nav-button" href="/dashboard.php">Dashboard</a></li>
-      <?php if (!empty($_SESSION['is_admin'])): ?>
-        <li><a class="nav-button" href="/admin/index.php">Admin</a></li>
-      <?php endif; ?>
-      <li><a class="nav-button" href="/logout.php">Logout</a></li>
+      <li><a href="/dashboard.php">Dashboard</a></li>
+      <li><a href="/logout.php">Logout</a></li>
 <?php endif; ?>
     </ul>
   </nav>

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -1,0 +1,10 @@
+<button class="side-nav-toggle">☰</button>
+<nav class="side-nav">
+  <ul>
+    <li><a href="services.php">Services</a></li>
+    <li><a href="buy.php">Buy</a></li>
+    <li><a href="sell.php">Sell</a></li>
+    <li><a href="trade.php">Trade</a></li>
+    <li><a href="forum/">Forum</a></li>
+  </ul>
+</nav>

--- a/includes/user.php
+++ b/includes/user.php
@@ -15,7 +15,11 @@ function username_with_avatar(mysqli $conn, int $user_id, ?string $username = nu
         $stmt->execute();
         $stmt->bind_result($path);
         if ($stmt->fetch() && $path) {
-            $avatar = '/assets/avatars/' . $path;
+            if (strpos($path, '/') !== false) {
+                $avatar = $path;
+            } else {
+                $avatar = '/assets/avatars/' . $path;
+            }
         }
         $stmt->close();
     }

--- a/index.php
+++ b/index.php
@@ -8,10 +8,17 @@
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
 
   <div class="hero">
-    <img src="assets/logo.png" alt="SkuzE logo" class="hero-logo" />
+    <pre class="hero-ascii">
+ ____  _              _____
+/ ___|| | ___   _ ___| ____|
+\___ \| |/ / | | |_  /  _|
+ ___) |   <| |_| |/ /| |___
+|____/|_|\_\\__,_/___|_____|
+    </pre>
     <h2>Repair. Modding. Modern Support.</h2>
     <p>Get started below. Whether you're fixing, upgrading, or building — SkuzE has you covered.</p>
 

--- a/login.php
+++ b/login.php
@@ -166,6 +166,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && empty($error)) {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Login</h2>
   <?php if (!empty($error)) echo "<p style='color:red;'>" . htmlspecialchars($error) . "</p>"; ?>

--- a/my-listings.php
+++ b/my-listings.php
@@ -30,6 +30,7 @@ $stmt->close();
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>My Listings</h2>
   <p><a href="sell.php">Create a new listing</a></p>

--- a/my-requests.php
+++ b/my-requests.php
@@ -24,6 +24,7 @@ if ($stmt === false) {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>My Requests</h2>
   <p><a href="dashboard.php">← Back to Dashboard</a></p>

--- a/register.php
+++ b/register.php
@@ -97,6 +97,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Register</h2>
   <?php if (!empty($error)) echo "<p style='color:red;'>" . htmlspecialchars($error) . "</p>"; ?>

--- a/reset.php
+++ b/reset.php
@@ -87,6 +87,7 @@ if ($token) {
 <html>
 <head><title>Reset Password</title></head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Reset Password</h2>
   <?php if (!empty($error)) echo "<p style='color:red;'>" . htmlspecialchars($error) . "</p>"; ?>

--- a/sell-step.php
+++ b/sell-step.php
@@ -20,6 +20,7 @@ function label($text, $name, $type = 'text', $required = true) {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Sell - <?= htmlspecialchars(ucfirst($category)) ?> Details</h2>
 

--- a/sell.php
+++ b/sell.php
@@ -70,6 +70,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Create a Listing</h2>
   <?php if ($error): ?>

--- a/service-step.php
+++ b/service-step.php
@@ -25,6 +25,7 @@ function label($text, $name, $type = 'text', $required = true) {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Service - <?= htmlspecialchars(ucfirst($category)) ?> Details</h2>
 

--- a/services.php
+++ b/services.php
@@ -9,6 +9,7 @@ require 'includes/csrf.php';
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
 
   <h2>Select a Service</h2>

--- a/submit-request.php
+++ b/submit-request.php
@@ -98,6 +98,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <?php if ($success): ?>
     <h2>Request Submitted</h2>

--- a/success.php
+++ b/success.php
@@ -8,6 +8,7 @@ require 'includes/auth.php';
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Payment Successful</h2>
   <p>Your payment was processed successfully.</p>

--- a/trade-step.php
+++ b/trade-step.php
@@ -20,6 +20,7 @@ function label($text, $name, $type = 'text', $required = true) {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Trade - <?= htmlspecialchars(ucfirst($category)) ?> Details</h2>
 

--- a/trade.php
+++ b/trade.php
@@ -52,6 +52,7 @@ if ($stmt) {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
 
   <?php if ($db_error): ?>

--- a/verify.php
+++ b/verify.php
@@ -64,6 +64,7 @@ if ($token) {
 <html>
 <head><title>Verify</title></head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Email Verification</h2>
   <p><?= $msg ?></p>

--- a/view-profile.php
+++ b/view-profile.php
@@ -40,6 +40,7 @@ if ($viewer === $target) {
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
+  <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2><?= htmlspecialchars($username); ?></h2>
   <?php if ($isPrivate && !$isFriend): ?>


### PR DESCRIPTION
## Summary
- Add `.logo-img` class to header logo and style for responsive sizing
- Simplify navigation to Home/About plus conditional auth links
- Remove unused navigation button styles
- Introduce collapsible sidebar listing core pages and load it after `<body>` on top-level pages
- Add CSS and JavaScript to toggle the sidebar
- Normalize avatar handling to store only filenames and honor existing paths
- Replace hero logo image with ASCII art and style via `.hero-ascii`

## Testing
- `php -l includes/user.php profile.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab75a88c1c832b80c2f052c630b56c