### PR TITLE
Align header horizontally and resize logo

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -120,17 +120,6 @@ body {
   background: rgba(255, 255, 255, 0.1);
 }
 
-.secondary-links {
-  text-align: center;
-  margin-top: 2rem;
-  font-size: 0.9rem;
-}
-
-.secondary-links a {
-  margin: 0 0.5rem;
-  color: var(--accent);
-  text-decoration: none;
-}
 #theme-toggle {
   position: fixed;
   top: 1rem;
@@ -162,17 +151,18 @@ footer {
 }
 
 /* Navigation */
+
 .site-header {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  justify-content: space-between;
   align-items: center;
-  gap: 1rem;
-  padding: 1rem 0;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
 }
 
 .logo-img {
-  max-width: 100px;
-  width: 100%;
+  max-width: 60px;
   height: auto;
 }
 
@@ -311,11 +301,6 @@ tbody tr:nth-child(even) {
 }
 
 @media (min-width: 600px) {
-  .site-header {
-    flex-direction: row;
-    justify-content: space-between;
-  }
-
   .site-nav ul {
     gap: 2rem;
   }

--- a/includes/header.php
+++ b/includes/header.php
@@ -54,6 +54,7 @@ if (file_exists($settingsFile)) {
     <ul>
       <li><a href="/index.php">Home</a></li>
       <li><a href="/about.php">About</a></li>
+      <li><a href="/help.php">Help/FAQ</a></li>
 <?php if (empty($_SESSION['user_id'])): ?>
       <li><a href="/login.php">Login</a></li>
       <li><a href="/register.php">Register</a></li>

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -1,5 +1,5 @@
 <button class="side-nav-toggle">☰</button>
-<nav class="side-nav">
+<nav class="side-nav" aria-label="Primary navigation">
   <ul>
     <li><a href="services.php">Services</a></li>
     <li><a href="buy.php">Buy</a></li>

--- a/index.php
+++ b/index.php
@@ -20,24 +20,8 @@
 |____/|_|\_\\__,_/___|_____|
     </pre>
     <h2>Repair. Modding. Modern Support.</h2>
-    <p>Get started below. Whether you're fixing, upgrading, or building — SkuzE has you covered.</p>
+    <p>Whether you're fixing, upgrading, or building — SkuzE has you covered.</p>
 
-    <div class="cta-buttons">
-      <a href="services.php">Services</a>
-      <a href="buy.php">Buy</a>
-      <a href="sell.php">Sell</a>
-      <a href="trade.php">Trade</a>
-    </div>
-
-    <div class="secondary-links">
-      <a href="about.php">About</a>
-      <a href="help.php">Help/FAQ</a>
-      <?php if(isset($_SESSION['user_id'])): ?>
-        <a href="dashboard.php">Dashboard</a>
-      <?php else: ?>
-        <a href="login.php">Login / Register</a>
-      <?php endif; ?>
-    </div>
   </div>
 
   <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- Lay out site header horizontally with compact spacing
- Limit logo image to 60px width for consistent sizing
- Remove redundant secondary links on landing page and add Help/FAQ to global header
- Drop duplicate hero CTAs and designate sidebar as primary navigation

## Testing
- `composer validate --no-check-publish`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7c0bfff4832b8f2c7ecf0d256cd9