### PR TITLE
Add global search endpoint with pagination and header search bar

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -27,6 +27,7 @@ $requests = $stmt->fetch_all(MYSQLI_ASSOC);
   <p><a href="listings.php">Review Listings</a></p>
   <p><a href="trade-requests.php">Review Trade Requests</a></p>
   <p><a href="discount-codes.php">Manage Discount Codes</a></p>
+  <p><a href="users.php">Manage Users</a></p>
   <p><a href="theme.php">Vaporwave Theme Settings</a></p>
   <p><a href="../dashboard.php">Back to Dashboard</a></p>
 

--- a/admin/user-edit.php
+++ b/admin/user-edit.php
@@ -1,0 +1,98 @@
+<?php
+require '../includes/auth.php';
+require '../includes/db.php';
+require '../includes/user.php';
+require '../includes/csrf.php';
+
+if (!$_SESSION['is_admin']) {
+  header('Location: ../dashboard.php');
+  exit;
+}
+
+$statuses = ['online', 'offline', 'busy'];
+$id = (int)($_GET['id'] ?? 0);
+if ($id <= 0) {
+  header('Location: users.php');
+  exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!validate_token($_POST['csrf_token'] ?? '')) {
+    $error = 'Invalid CSRF token.';
+  } else {
+    $email = trim($_POST['email'] ?? '');
+    $status = $_POST['status'] ?? 'offline';
+    $is_admin = isset($_POST['is_admin']) ? 1 : 0;
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+      $error = 'Please enter a valid email.';
+    } elseif (!in_array($status, $statuses, true)) {
+      $error = 'Invalid status.';
+    } else {
+      $stmt = $conn->prepare('UPDATE users SET email = ?, status = ?, is_admin = ? WHERE id = ?');
+      if ($stmt) {
+        $stmt->bind_param('ssii', $email, $status, $is_admin, $id);
+        if ($stmt->execute()) {
+          $success = 'User updated successfully.';
+        } else {
+          error_log('Execute failed for user update: ' . $stmt->error);
+          $error = 'Failed to update user.';
+        }
+        $stmt->close();
+      } else {
+        error_log('Prepare failed for user update: ' . $conn->error);
+        $error = 'Failed to update user.';
+      }
+    }
+  }
+}
+
+$stmt = $conn->prepare('SELECT username, email, status, is_admin FROM users WHERE id = ?');
+if ($stmt) {
+  $stmt->bind_param('i', $id);
+  $stmt->execute();
+  $stmt->bind_result($username, $email, $status, $is_admin);
+  if (!$stmt->fetch()) {
+    $stmt->close();
+    header('Location: users.php');
+    exit;
+  }
+  $stmt->close();
+} else {
+  error_log('Prepare failed fetching user: ' . $conn->error);
+  header('Location: users.php');
+  exit;
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Edit User</title>
+  <link rel="stylesheet" href="../assets/style.css">
+</head>
+<body>
+  <?php include '../includes/header.php'; ?>
+  <h2>Edit User <?= htmlspecialchars($username) ?></h2>
+  <?php if (!empty($error)) echo '<p style="color:red;">' . htmlspecialchars($error) . '</p>'; ?>
+  <?php if (!empty($success)) echo '<p style="color:green;">' . htmlspecialchars($success) . '</p>'; ?>
+  <form method="post">
+    <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+    <label>Email:
+      <input type="email" name="email" required value="<?= htmlspecialchars($email) ?>">
+    </label><br>
+    <label>Status:
+      <select name="status">
+        <?php foreach ($statuses as $opt): ?>
+          <option value="<?= htmlspecialchars($opt) ?>" <?= $status === $opt ? 'selected' : '' ?>><?= htmlspecialchars(ucfirst($opt)) ?></option>
+        <?php endforeach; ?>
+      </select>
+    </label><br>
+    <label>
+      <input type="checkbox" name="is_admin" value="1" <?= $is_admin ? 'checked' : '' ?>> Admin
+    </label><br>
+    <button type="submit">Save</button>
+  </form>
+  <p><a href="users.php">Back to Users</a></p>
+  <?php include '../includes/footer.php'; ?>
+</body>
+</html>

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,0 +1,124 @@
+<?php
+require '../includes/auth.php';
+require '../includes/db.php';
+require '../includes/user.php';
+require '../includes/csrf.php';
+
+if (!$_SESSION['is_admin']) {
+  header("Location: ../dashboard.php");
+  exit;
+}
+
+$errors = [];
+$messages = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!validate_token($_POST['csrf_token'] ?? '')) {
+    $errors[] = 'Invalid CSRF token.';
+  } else {
+    $uid = (int)($_POST['user_id'] ?? 0);
+    if ($uid > 0) {
+      if (isset($_POST['reset_2fa'])) {
+        $secret = bin2hex(random_bytes(10));
+        $code = bin2hex(random_bytes(10));
+        $stmt = $conn->prepare('REPLACE INTO user_2fa (user_id, secret, recovery_code) VALUES (?, ?, ?)');
+        if ($stmt) {
+          $stmt->bind_param('iss', $uid, $secret, $code);
+          if ($stmt->execute()) {
+            $messages[] = "2FA reset for user ID $uid. Secret: $secret Recovery: $code";
+          } else {
+            error_log('Execute failed for reset_2fa: ' . $stmt->error);
+            $errors[] = 'Failed to reset 2FA.';
+          }
+          $stmt->close();
+        } else {
+          error_log('Prepare failed for reset_2fa: ' . $conn->error);
+          $errors[] = 'Failed to reset 2FA.';
+        }
+      } elseif (isset($_POST['delete_user'])) {
+        $stmt = $conn->prepare('DELETE FROM user_2fa WHERE user_id = ?');
+        if ($stmt) {
+          $stmt->bind_param('i', $uid);
+          $stmt->execute();
+          $stmt->close();
+        }
+        $stmt = $conn->prepare('DELETE FROM users WHERE id = ?');
+        if ($stmt) {
+          $stmt->bind_param('i', $uid);
+          if ($stmt->execute()) {
+            $messages[] = "Deleted user ID $uid.";
+          } else {
+            error_log('Execute failed for delete_user: ' . $stmt->error);
+            $errors[] = 'Failed to delete user.';
+          }
+          $stmt->close();
+        } else {
+          error_log('Prepare failed for delete_user: ' . $conn->error);
+          $errors[] = 'Failed to delete user.';
+        }
+      }
+    }
+  }
+}
+
+$users = [];
+if ($result = $conn->query('SELECT id, username, email, status, is_admin FROM users ORDER BY id ASC')) {
+  $users = $result->fetch_all(MYSQLI_ASSOC);
+  $result->close();
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Manage Users</title>
+  <link rel="stylesheet" href="../assets/style.css">
+</head>
+<body>
+  <?php include '../includes/header.php'; ?>
+  <h2>Manage Users</h2>
+  <?php foreach ($errors as $e): ?>
+    <p style="color:red;"><?= htmlspecialchars($e) ?></p>
+  <?php endforeach; ?>
+  <?php foreach ($messages as $m): ?>
+    <p style="color:green;"><?= htmlspecialchars($m) ?></p>
+  <?php endforeach; ?>
+  <table>
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Username</th>
+        <th>Email</th>
+        <th>Status</th>
+        <th>Admin</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <?php foreach ($users as $u): ?>
+        <tr>
+          <td><?= $u['id'] ?></td>
+          <td><?= username_with_avatar($conn, $u['id'], $u['username']) ?></td>
+          <td><?= htmlspecialchars($u['email']) ?></td>
+          <td><?= htmlspecialchars($u['status']) ?></td>
+          <td><?= $u['is_admin'] ? 'Yes' : 'No' ?></td>
+          <td>
+            <a href="../view-profile.php?id=<?= $u['id'] ?>">View</a>
+            <a href="user-edit.php?id=<?= $u['id'] ?>">Edit</a>
+            <form method="post" style="display:inline;">
+              <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+              <input type="hidden" name="user_id" value="<?= $u['id'] ?>">
+              <button type="submit" name="reset_2fa">Reset 2FA</button>
+            </form>
+            <form method="post" style="display:inline;" onsubmit="return confirm('Delete this user?');">
+              <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+              <input type="hidden" name="user_id" value="<?= $u['id'] ?>">
+              <button type="submit" name="delete_user">Delete</button>
+            </form>
+          </td>
+        </tr>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+  <?php include '../includes/footer.php'; ?>
+</body>
+</html>

--- a/assets/style.css
+++ b/assets/style.css
@@ -23,6 +23,15 @@
   --gradient: linear-gradient(-45deg, var(--vap1), var(--vap2), var(--vap3), var(--vap1));
 }
 
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --bg: #1b1135;
+    --fg: #e0d9f6;
+    --accent: #01cdfe;
+    --gradient: linear-gradient(135deg, #2d1e59 0%, #09002e 100%);
+  }
+}
+
 html[data-theme='vaporwave'] body {
   background-size: 400% 400%;
   animation: gradientFlow var(--vap-speed) ease infinite;
@@ -42,10 +51,19 @@ html[data-theme='vaporwave'] body {
 
 body {
   background: var(--gradient);
+  background-attachment: fixed;
+  background-repeat: no-repeat;
+  background-size: cover;
   color: var(--fg);
   font-family: Georgia, serif;
   margin: 0;
   padding: 1rem;
+}
+
+@media (max-width: 600px) {
+  body {
+    background-position: center;
+  }
 }
 
 .hero {
@@ -159,6 +177,8 @@ footer {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
+  perspective: 500px;
 }
 
 .logo-img {
@@ -174,6 +194,24 @@ footer {
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.site-nav a {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  border-radius: 3px;
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.4);
+  transition: background 0.2s, transform 0.1s, box-shadow 0.1s;
+}
+
+.site-nav a:hover {
+  background: #777;
+  color: #fff;
+}
+
+.site-nav a:active {
+  transform: translateY(2px);
+  box-shadow: inset 0 2px 0 rgba(0, 0, 0, 0.4);
 }
 
 /* Forms and buttons */
@@ -346,14 +384,17 @@ tbody tr:nth-child(even) {
   height: 100%;
   width: 200px;
   background: var(--bg);
-  transform: translateX(-100%);
+  box-shadow: 4px 0 8px rgba(0, 0, 0, 0.3);
+  transform: translateX(-100%) rotateY(45deg);
+  transform-origin: left center;
   transition: transform 0.3s ease;
   z-index: 1000;
   padding-top: 2rem;
+  perspective: 800px;
 }
 
 .side-nav.open {
-  transform: translateX(0);
+  transform: translateX(0) rotateY(0deg);
 }
 
 .side-nav ul {
@@ -382,4 +423,11 @@ tbody tr:nth-child(even) {
   padding: 0.5rem;
   cursor: pointer;
   z-index: 1001;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  transform: perspective(400px) translateZ(0);
+  transition: transform 0.2s ease;
+}
+
+.side-nav-toggle:hover {
+  transform: perspective(400px) translateZ(6px);
 }

--- a/includes/header.php
+++ b/includes/header.php
@@ -64,6 +64,9 @@ if (file_exists($settingsFile)) {
 <?php endif; ?>
     </ul>
   </nav>
+  <form class="site-search" action="/search.php" method="get">
+    <input type="text" name="q" placeholder="Search..." value="<?= htmlspecialchars($_GET['q'] ?? '') ?>">
+  </form>
   <button id="theme-toggle">Toggle Theme</button>
 </header>
 <script src="/assets/theme-toggle.js" defer></script>

--- a/index.php
+++ b/index.php
@@ -21,7 +21,11 @@
     </pre>
     <h2>Repair. Modding. Modern Support.</h2>
     <p>Whether you're fixing, upgrading, or building — SkuzE has you covered.</p>
-
+    <div class="cta-buttons">
+      <a href="buy.php">Buy</a>
+      <a href="sell.php">Sell</a>
+      <a href="services.php">Services</a>
+    </div>
   </div>
 
   <?php include 'includes/footer.php'; ?>

--- a/search.php
+++ b/search.php
@@ -1,0 +1,204 @@
+<?php
+session_start();
+require 'includes/db.php';
+require 'includes/user.php';
+
+$q = trim($_GET['q'] ?? '');
+$category = trim($_GET['category'] ?? '');
+$role = trim($_GET['role'] ?? '');
+$page = max(1, (int)($_GET['page'] ?? 1));
+$perPage = 10;
+$offset = ($page - 1) * $perPage;
+
+$userResults = $listingResults = $tradeResults = [];
+$totalUserPages = $totalListingPages = $totalTradePages = 0;
+
+if ($q !== '') {
+    // Users search
+    $like = "%{$q}%";
+    $countSql = "SELECT COUNT(*) FROM users WHERE username LIKE ?";
+    $countParams = [$like];
+    $countTypes = 's';
+    if ($role !== '') {
+        $countSql .= " AND status = ?";
+        $countParams[] = $role;
+        $countTypes .= 's';
+    }
+    if ($stmt = $conn->prepare($countSql)) {
+        $stmt->bind_param($countTypes, ...$countParams);
+        $stmt->execute();
+        $stmt->bind_result($totalUsers);
+        $stmt->fetch();
+        $stmt->close();
+        $totalUserPages = (int)ceil($totalUsers / $perPage);
+    }
+
+    $userSql = "SELECT id, username, status FROM users WHERE username LIKE ?";
+    $userParams = [$like];
+    $userTypes = 's';
+    if ($role !== '') {
+        $userSql .= " AND status = ?";
+        $userParams[] = $role;
+        $userTypes .= 's';
+    }
+    $userSql .= " ORDER BY username LIMIT ? OFFSET ?";
+    $userParams[] = $perPage;
+    $userParams[] = $offset;
+    $userTypes .= 'ii';
+    if ($stmt = $conn->prepare($userSql)) {
+        $stmt->bind_param($userTypes, ...$userParams);
+        $stmt->execute();
+        $userResults = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+    }
+
+    // Listings search
+    $countSql = "SELECT COUNT(*) FROM listings WHERE (title LIKE ? OR description LIKE ? OR category LIKE ?)";
+    $countParams = [$like, $like, $like];
+    $countTypes = 'sss';
+    if ($category !== '') {
+        $countSql .= " AND category = ?";
+        $countParams[] = $category;
+        $countTypes .= 's';
+    }
+    if ($stmt = $conn->prepare($countSql)) {
+        $stmt->bind_param($countTypes, ...$countParams);
+        $stmt->execute();
+        $stmt->bind_result($totalListings);
+        $stmt->fetch();
+        $stmt->close();
+        $totalListingPages = (int)ceil($totalListings / $perPage);
+    }
+
+    $listSql = "SELECT l.id, l.title, l.description, l.category, COALESCE(COUNT(r.id),0) AS trades
+                FROM listings l
+                LEFT JOIN service_requests r ON r.listing_id = l.id AND r.type='trade'
+                WHERE (l.title LIKE ? OR l.description LIKE ? OR l.category LIKE ?)";
+    $listParams = [$like, $like, $like];
+    $listTypes = 'sss';
+    if ($category !== '') {
+        $listSql .= " AND l.category = ?";
+        $listParams[] = $category;
+        $listTypes .= 's';
+    }
+    $listSql .= " GROUP BY l.id ORDER BY l.created_at DESC LIMIT ? OFFSET ?";
+    $listParams[] = $perPage;
+    $listParams[] = $offset;
+    $listTypes .= 'ii';
+    if ($stmt = $conn->prepare($listSql)) {
+        $stmt->bind_param($listTypes, ...$listParams);
+        $stmt->execute();
+        $listingResults = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+    }
+
+    // Trade requests search
+    $countSql = "SELECT COUNT(*) FROM service_requests WHERE type='trade' AND (make LIKE ? OR model LIKE ? OR device_type LIKE ?)";
+    $countParams = [$like, $like, $like];
+    $countTypes = 'sss';
+    if ($stmt = $conn->prepare($countSql)) {
+        $stmt->bind_param($countTypes, ...$countParams);
+        $stmt->execute();
+        $stmt->bind_result($totalTrades);
+        $stmt->fetch();
+        $stmt->close();
+        $totalTradePages = (int)ceil($totalTrades / $perPage);
+    }
+
+    $tradeSql = "SELECT r.id, r.make, r.model, r.device_type, u.username
+                 FROM service_requests r
+                 JOIN users u ON r.user_id = u.id
+                 WHERE r.type='trade' AND (r.make LIKE ? OR r.model LIKE ? OR r.device_type LIKE ?)
+                 ORDER BY r.created_at DESC LIMIT ? OFFSET ?";
+    $tradeParams = [$like, $like, $like, $perPage, $offset];
+    $tradeTypes = 'sssii';
+    if ($stmt = $conn->prepare($tradeSql)) {
+        $stmt->bind_param($tradeTypes, ...$tradeParams);
+        $stmt->execute();
+        $tradeResults = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+    }
+}
+
+$totalPages = max($totalUserPages, $totalListingPages, $totalTradePages);
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Search Results</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <h2>Search Results</h2>
+  <form method="get" class="search-filters">
+    <input type="text" name="q" value="<?= htmlspecialchars($q) ?>" placeholder="Search...">
+    <select name="category">
+      <option value="">All Categories</option>
+      <option value="phone" <?= $category==='phone'?'selected':'' ?>>Phone</option>
+      <option value="console" <?= $category==='console'?'selected':'' ?>>Game Console</option>
+      <option value="pc" <?= $category==='pc'?'selected':'' ?>>PC</option>
+      <option value="other" <?= $category==='other'?'selected':'' ?>>Other</option>
+    </select>
+    <select name="role">
+      <option value="">All Roles</option>
+      <option value="admin" <?= $role==='admin'?'selected':'' ?>>Admin</option>
+      <option value="user" <?= $role==='user'?'selected':'' ?>>User</option>
+    </select>
+    <button type="submit">Search</button>
+  </form>
+<?php if ($q === ''): ?>
+  <p>Please enter a search query.</p>
+<?php else: ?>
+  <section>
+    <h3>Users</h3>
+    <?php if ($userResults): ?>
+      <ul>
+      <?php foreach ($userResults as $u): ?>
+        <li><a href="view-profile.php?id=<?= $u['id']; ?>"><?= htmlspecialchars($u['username']) ?></a> (<?= htmlspecialchars($u['status']) ?>)</li>
+      <?php endforeach; ?>
+      </ul>
+    <?php else: ?>
+      <p>No users found.</p>
+    <?php endif; ?>
+  </section>
+  <section>
+    <h3>Listings</h3>
+    <?php if ($listingResults): ?>
+      <ul>
+      <?php foreach ($listingResults as $l): ?>
+        <li><a href="checkout.php?listing_id=<?= $l['id']; ?>"><?= htmlspecialchars($l['title']) ?></a> - <?= htmlspecialchars($l['category']) ?> (<?= htmlspecialchars($l['trades']) ?> trades)</li>
+      <?php endforeach; ?>
+      </ul>
+    <?php else: ?>
+      <p>No listings found.</p>
+    <?php endif; ?>
+  </section>
+  <section>
+    <h3>Trade Requests</h3>
+    <?php if ($tradeResults): ?>
+      <ul>
+      <?php foreach ($tradeResults as $t): ?>
+        <li><?= htmlspecialchars($t['make']) ?> <?= htmlspecialchars($t['model']) ?> (<?= htmlspecialchars($t['device_type']) ?>) by <?= htmlspecialchars($t['username']) ?></li>
+      <?php endforeach; ?>
+      </ul>
+    <?php else: ?>
+      <p>No trade requests found.</p>
+    <?php endif; ?>
+  </section>
+  <?php if ($totalPages > 1): ?>
+    <nav class="pagination">
+      <?php if ($page > 1): ?>
+        <a href="?<?= http_build_query(array_merge($_GET, ['page' => $page - 1])) ?>">&laquo; Prev</a>
+      <?php endif; ?>
+      <?php if ($page < $totalPages): ?>
+        <a href="?<?= http_build_query(array_merge($_GET, ['page' => $page + 1])) ?>">Next &raquo;</a>
+      <?php endif; ?>
+    </nav>
+  <?php endif; ?>
+<?php endif; ?>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Implement `search.php` to query users, listings, and trade requests with filters and pagination
- Add header search bar to submit queries to new endpoint
- Link admin dashboard to new user management pages
- Provide admin-only user management interface for viewing, editing, resetting 2FA, and deleting users
- Add user editing form with CSRF protection and role controls
- Style sidebar with box-shadow, perspective transforms, and responsive background
- Give header navigation a 3D look with interactive hover/click states and center main landing page buttons

## Testing
- `npx --yes stylelint assets/style.css --formatter json`
- `php -l index.php`
- `php -l includes/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68abd5759170832b929c857accfab5c0