### PR TITLE
Add trade listings, offers, and VIP membership

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -27,6 +27,7 @@ $requests = $stmt->fetch_all(MYSQLI_ASSOC);
   <p><a href="discount-codes.php">Manage Discount Codes</a></p>
   <p><a href="users.php">Manage Users</a></p>
   <p><a href="theme.php">Vaporwave Theme Settings</a></p>
+  <p><a href="toolbox.php">Manage Toolbox</a></p>
   <p><a href="../dashboard.php">Back to Dashboard</a></p>
 
   <table>

--- a/admin/toolbox.php
+++ b/admin/toolbox.php
@@ -1,0 +1,125 @@
+<?php
+require '../includes/auth.php';
+require '../includes/csrf.php';
+
+if (!$_SESSION['is_admin']) {
+  header('Location: ../dashboard.php');
+  exit;
+}
+
+$toolsPath = __DIR__ . '/../assets/tools.json';
+$tools = [];
+if (file_exists($toolsPath)) {
+  $json = file_get_contents($toolsPath);
+  $decoded = json_decode($json, true);
+  if (is_array($decoded)) {
+    $tools = $decoded;
+  }
+}
+
+$errors = [];
+$messages = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!validate_token($_POST['csrf_token'] ?? '')) {
+    $errors[] = 'Invalid CSRF token.';
+  } else {
+    if (isset($_POST['add'])) {
+      $tool = [
+        'category' => trim($_POST['category'] ?? ''),
+        'name' => trim($_POST['name'] ?? ''),
+        'description' => trim($_POST['description'] ?? ''),
+        'url' => trim($_POST['url'] ?? ''),
+      ];
+      $tools[] = $tool;
+      if (file_put_contents($toolsPath, json_encode($tools, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) !== false) {
+        $messages[] = 'Tool added.';
+      } else {
+        $errors[] = 'Failed to save tool list.';
+      }
+    } elseif (isset($_POST['update'])) {
+      $idx = (int)($_POST['index'] ?? -1);
+      if (isset($tools[$idx])) {
+        $tools[$idx]['category'] = trim($_POST['category'] ?? '');
+        $tools[$idx]['name'] = trim($_POST['name'] ?? '');
+        $tools[$idx]['description'] = trim($_POST['description'] ?? '');
+        $tools[$idx]['url'] = trim($_POST['url'] ?? '');
+        if (file_put_contents($toolsPath, json_encode($tools, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) !== false) {
+          $messages[] = 'Tool updated.';
+        } else {
+          $errors[] = 'Failed to save tool list.';
+        }
+      }
+    } elseif (isset($_POST['delete'])) {
+      $idx = (int)($_POST['index'] ?? -1);
+      if (isset($tools[$idx])) {
+        array_splice($tools, $idx, 1);
+        if (file_put_contents($toolsPath, json_encode($tools, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)) !== false) {
+          $messages[] = 'Tool removed.';
+        } else {
+          $errors[] = 'Failed to save tool list.';
+        }
+      }
+    }
+  }
+}
+?>
+<?php require '../includes/layout.php'; ?>
+  <meta charset="UTF-8">
+  <title>Manage Toolbox</title>
+  <link rel="stylesheet" href="../assets/style.css">
+</head>
+<body>
+  <?php include '../includes/header.php'; ?>
+  <h2>Manage Toolbox</h2>
+  <?php foreach ($errors as $e): ?>
+    <p style="color:red;"><?= htmlspecialchars($e) ?></p>
+  <?php endforeach; ?>
+  <?php foreach ($messages as $m): ?>
+    <p style="color:green;"><?= htmlspecialchars($m) ?></p>
+  <?php endforeach; ?>
+  <table>
+    <thead>
+      <tr>
+        <th>Category</th>
+        <th>Name</th>
+        <th>Description</th>
+        <th>URL</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <?php foreach ($tools as $i => $tool): ?>
+      <tr>
+        <form method="post">
+          <td><input type="text" name="category" value="<?= htmlspecialchars($tool['category']) ?>"></td>
+          <td><input type="text" name="name" value="<?= htmlspecialchars($tool['name']) ?>"></td>
+          <td><input type="text" name="description" value="<?= htmlspecialchars($tool['description']) ?>"></td>
+          <td><input type="url" name="url" value="<?= htmlspecialchars($tool['url']) ?>"></td>
+          <td>
+            <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+            <input type="hidden" name="index" value="<?= $i ?>">
+            <button type="submit" name="update">Update</button>
+            <button type="submit" name="delete" onclick="return confirm('Delete this tool?');">Delete</button>
+          </td>
+        </form>
+      </tr>
+      <?php endforeach; ?>
+      <tr>
+        <form method="post">
+          <td><input type="text" name="category"></td>
+          <td><input type="text" name="name"></td>
+          <td><input type="text" name="description"></td>
+          <td><input type="url" name="url"></td>
+          <td>
+            <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+            <button type="submit" name="add">Add</button>
+          </td>
+        </form>
+      </tr>
+    </tbody>
+  </table>
+  <p><a href="../toolbox.php">View Toolbox</a></p>
+  <?php include '../includes/footer.php'; ?>
+</body>
+</html>

--- a/assets/style.css
+++ b/assets/style.css
@@ -247,6 +247,22 @@ footer:hover {
   border-radius: 50%;
 }
 
+.vip-badge {
+  background: gold;
+  color: #000;
+  font-size: 0.75em;
+  padding: 2px 4px;
+  border-radius: 3px;
+  margin-left: 4px;
+}
+
+.notice {
+  background: #fffae6;
+  border: 1px solid #eedc82;
+  padding: 0.5rem;
+  margin: 0.5rem 0;
+}
+
 /* Navigation */
 
 .site-header {

--- a/assets/tools.json
+++ b/assets/tools.json
@@ -1,0 +1,20 @@
+[
+  {
+    "category": "conversions",
+    "name": "Unit Converter",
+    "description": "Convert between various units.",
+    "url": "https://www.unitconverters.net/"
+  },
+  {
+    "category": "news",
+    "name": "Techmeme",
+    "description": "Tech news aggregator.",
+    "url": "https://www.techmeme.com/"
+  },
+  {
+    "category": "software",
+    "name": "Ninite",
+    "description": "Install multiple apps quickly.",
+    "url": "https://ninite.com/"
+  }
+]

--- a/config.example.php
+++ b/config.example.php
@@ -12,6 +12,10 @@ return [
   'smtp_pass' => 'your_email_password',
   'smtp_port' => 465,
 
+  // Google AdSense configuration
+  'adsense_client' => 'ca-pub-XXXXXXXXXXXXXXXX',
+  'adsense_slot' => '1234567890',
+
   // Stripe secret API key used for payment processing
   'stripe_secret' => 'your_stripe_secret_key'
 ];

--- a/dashboard.php
+++ b/dashboard.php
@@ -4,7 +4,9 @@ require 'includes/db.php';
 
 $id = $_SESSION['user_id'];
 $username = '';
-$stmt = $conn->prepare("SELECT username FROM users WHERE id = ?");
+$vip = 0;
+$vip_expires = null;
+$stmt = $conn->prepare("SELECT username, vip_status, vip_expires_at FROM users WHERE id = ?");
 if ($stmt === false) {
   error_log('Prepare failed: ' . $conn->error);
 } else {
@@ -12,11 +14,12 @@ if ($stmt === false) {
   if (!$stmt->execute()) {
     error_log('Execute failed: ' . $stmt->error);
   } else {
-    $stmt->bind_result($username);
+    $stmt->bind_result($username, $vip, $vip_expires);
     $stmt->fetch();
     $stmt->close();
   }
 }
+$vip_active = $vip && (!$vip_expires || strtotime($vip_expires) > time());
 ?>
 <?php require 'includes/layout.php'; ?>
   <title>Dashboard</title>
@@ -27,6 +30,14 @@ if ($stmt === false) {
   <?php include 'includes/header.php'; ?>
 
   <h2>Welcome, <?= htmlspecialchars($username) ?></h2>
+  <?php if ($vip_active): ?>
+    <?php $expiresTs = strtotime($vip_expires); $days = floor(($expiresTs - time())/86400); ?>
+    <?php if ($days <= 7): ?>
+      <p class="notice">Your VIP membership expires on <?= htmlspecialchars($vip_expires) ?>. <a href="vip.php">Renew now</a>.</p>
+    <?php endif; ?>
+  <?php elseif ($vip): ?>
+    <p class="notice">Your VIP membership expired on <?= htmlspecialchars($vip_expires) ?>. <a href="vip.php">Renew now</a>.</p>
+  <?php endif; ?>
   <p><a href="services.php">Start a Service Request</a></p>
   <p><a href="my-requests.php">View My Service Requests</a></p>
   <p><a href="my-listings.php">Manage My Listings</a></p>

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -5,6 +5,10 @@
     <li><a href="buy.php">Buy</a></li>
     <li><a href="sell.php">Sell</a></li>
     <li><a href="trade.php">Trade</a></li>
+    <li><a href="trade-listings.php">Trade Listings</a></li>
+    <li><a href="promoted.php">Promoted Shops</a></li>
+    <li><a href="vip.php">VIP Membership</a></li>
+    <li><a href="toolbox.php">Toolbox</a></li>
     <li><a href="forum/">Forum</a></li>
   </ul>
 </nav>

--- a/includes/user.php
+++ b/includes/user.php
@@ -1,14 +1,18 @@
 <?php
 function username_with_avatar(mysqli $conn, int $user_id, ?string $username = null): string {
-    if ($username === null) {
-        if ($stmt = $conn->prepare('SELECT username FROM users WHERE id = ?')) {
-            $stmt->bind_param('i', $user_id);
-            $stmt->execute();
-            $stmt->bind_result($username);
-            $stmt->fetch();
-            $stmt->close();
+    $vip = 0;
+    $vip_expires = null;
+    if ($stmt = $conn->prepare('SELECT username, vip_status, vip_expires_at FROM users WHERE id = ?')) {
+        $stmt->bind_param('i', $user_id);
+        $stmt->execute();
+        $stmt->bind_result($usernameFetched, $vip, $vip_expires);
+        $stmt->fetch();
+        $stmt->close();
+        if ($username === null) {
+            $username = $usernameFetched;
         }
     }
+
     $avatar = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48Y2lyY2xlIGN4PSI1MCIgY3k9IjUwIiByPSI1MCIgZmlsbD0iI2NjYyIvPjwvc3ZnPg==';
     $avatarDir = __DIR__ . '/../assets/avatars/';
     $avatarBase = '/assets/avatars/';
@@ -25,7 +29,13 @@ function username_with_avatar(mysqli $conn, int $user_id, ?string $username = nu
         }
         $stmt->close();
     }
+
+    $badge = '';
+    if ($vip && (!$vip_expires || strtotime($vip_expires) > time())) {
+        $badge = ' <span class="vip-badge">VIP</span>';
+    }
+
     return '<span class="user-display"><img src="' . htmlspecialchars($avatar, ENT_QUOTES, 'UTF-8') . '" alt="" class="avatar-sm">' .
-           htmlspecialchars($username ?? '', ENT_QUOTES, 'UTF-8') . '</span>';
+           htmlspecialchars($username ?? '', ENT_QUOTES, 'UTF-8') . $badge . '</span>';
 }
 ?>

--- a/promoted.php
+++ b/promoted.php
@@ -1,0 +1,64 @@
+<?php
+require 'includes/db.php';
+
+$configPath = __DIR__ . '/config.php';
+$config = file_exists($configPath) ? require $configPath : [];
+$adsenseClient = $config['adsense_client'] ?? '';
+$adsenseSlot = $config['adsense_slot'] ?? '';
+
+$shops = [];
+if ($stmt = $conn->prepare('SELECT id, username, company_name, company_website, company_logo FROM users WHERE account_type = "business" AND promoted = 1 AND (promoted_expires IS NULL OR promoted_expires > NOW()) ORDER BY promoted_expires DESC')) {
+    $stmt->execute();
+    $shops = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+}
+?>
+<?php require 'includes/layout.php'; ?>
+  <meta charset="UTF-8">
+  <title>Promoted Shops</title>
+<?php if ($adsenseClient): ?>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=<?= htmlspecialchars($adsenseClient, ENT_QUOTES, 'UTF-8'); ?>" crossorigin="anonymous"></script>
+<?php endif; ?>
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <h2>Promoted Shops</h2>
+  <?php if ($shops): ?>
+    <ul>
+      <?php foreach ($shops as $s): ?>
+        <?php $logo = $s['company_logo'] ? '/assets/logos/' . $s['company_logo'] : ''; ?>
+        <li>
+          <?php if ($logo): ?><img src="<?= htmlspecialchars($logo, ENT_QUOTES, 'UTF-8'); ?>" alt="Logo" width="50"> <?php endif; ?>
+          <?php if (!empty($s['company_website'])): ?>
+            <a href="<?= htmlspecialchars($s['company_website'], ENT_QUOTES, 'UTF-8'); ?>" target="_blank">
+              <?= htmlspecialchars($s['company_name'] ?: $s['username'], ENT_QUOTES, 'UTF-8'); ?>
+            </a>
+          <?php else: ?>
+            <a href="view-profile.php?id=<?= $s['id']; ?>">
+              <?= htmlspecialchars($s['company_name'] ?: $s['username'], ENT_QUOTES, 'UTF-8'); ?>
+            </a>
+          <?php endif; ?>
+        </li>
+      <?php endforeach; ?>
+    </ul>
+  <?php else: ?>
+    <p>No promoted shops at this time.</p>
+  <?php endif; ?>
+
+  <div class="ad-unit">
+  <?php if ($adsenseClient && $adsenseSlot): ?>
+    <ins class="adsbygoogle"
+         style="display:block"
+         data-ad-client="<?= htmlspecialchars($adsenseClient, ENT_QUOTES, 'UTF-8'); ?>"
+         data-ad-slot="<?= htmlspecialchars($adsenseSlot, ENT_QUOTES, 'UTF-8'); ?>"
+         data-ad-format="auto"
+         data-full-width-responsive="true"></ins>
+    <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+  <?php else: ?>
+    <p>Ad space</p>
+  <?php endif; ?>
+  </div>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>

--- a/schema/business_accounts.sql
+++ b/schema/business_accounts.sql
@@ -1,0 +1,5 @@
+ALTER TABLE users
+  ADD COLUMN account_type ENUM('standard','business') NOT NULL DEFAULT 'standard',
+  ADD COLUMN company_name VARCHAR(255) DEFAULT NULL,
+  ADD COLUMN company_website VARCHAR(255) DEFAULT NULL,
+  ADD COLUMN company_logo VARCHAR(255) DEFAULT NULL;

--- a/schema/promoted_users.sql
+++ b/schema/promoted_users.sql
@@ -1,0 +1,5 @@
+-- SQL schema to flag promoted shops
+
+ALTER TABLE users
+    ADD COLUMN promoted TINYINT(1) DEFAULT 0,
+    ADD COLUMN promoted_expires DATETIME;

--- a/schema/trade_tables.sql
+++ b/schema/trade_tables.sql
@@ -1,0 +1,27 @@
+-- SQL schema for trade listings feature
+
+CREATE TABLE trade_listings (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    owner_id INT NOT NULL,
+    have_item VARCHAR(255) NOT NULL,
+    want_item VARCHAR(255) NOT NULL,
+    status ENUM('open','accepted','closed') DEFAULT 'open',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (owner_id) REFERENCES users(id)
+);
+
+CREATE TABLE trade_offers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    listing_id INT NOT NULL,
+    offerer_id INT NOT NULL,
+    message TEXT,
+    offer_item VARCHAR(255) NOT NULL,
+    status ENUM('pending','accepted','declined') DEFAULT 'pending',
+    fulfillment_type ENUM('meetup','ship_to_skuzE'),
+    shipping_address TEXT,
+    meeting_location VARCHAR(255),
+    tracking_number VARCHAR(100),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (listing_id) REFERENCES trade_listings(id),
+    FOREIGN KEY (offerer_id) REFERENCES users(id)
+);

--- a/schema/vip_users.sql
+++ b/schema/vip_users.sql
@@ -1,0 +1,4 @@
+-- SQL schema to add VIP fields to users table
+ALTER TABLE users
+  ADD COLUMN vip_status TINYINT(1) NOT NULL DEFAULT 0,
+  ADD COLUMN vip_expires_at DATETIME DEFAULT NULL;

--- a/toolbox.php
+++ b/toolbox.php
@@ -1,0 +1,48 @@
+<?php
+require 'includes/db.php';
+
+$toolsPath = __DIR__ . '/assets/tools.json';
+$tools = [];
+if (file_exists($toolsPath)) {
+  $data = file_get_contents($toolsPath);
+  $decoded = json_decode($data, true);
+  if (is_array($decoded)) {
+    $tools = $decoded;
+  }
+}
+
+$grouped = [];
+foreach ($tools as $t) {
+  $cat = $t['category'] ?? 'misc';
+  $grouped[$cat][] = $t;
+}
+?>
+<?php require 'includes/layout.php'; ?>
+  <meta charset="UTF-8">
+  <title>Toolbox</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <h2>Toolbox</h2>
+  <?php if ($grouped): ?>
+    <?php foreach ($grouped as $category => $list): ?>
+      <h3><?= htmlspecialchars(ucfirst($category), ENT_QUOTES, 'UTF-8'); ?></h3>
+      <ul>
+      <?php foreach ($list as $tool): ?>
+        <li>
+          <a href="<?= htmlspecialchars($tool['url'], ENT_QUOTES, 'UTF-8'); ?>" target="_blank" rel="noopener">
+            <?= htmlspecialchars($tool['name'], ENT_QUOTES, 'UTF-8'); ?>
+          </a>
+          - <?= htmlspecialchars($tool['description'], ENT_QUOTES, 'UTF-8'); ?>
+        </li>
+      <?php endforeach; ?>
+      </ul>
+    <?php endforeach; ?>
+  <?php else: ?>
+    <p>No tools available.</p>
+  <?php endif; ?>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>

--- a/trade-fulfillment.php
+++ b/trade-fulfillment.php
@@ -1,0 +1,128 @@
+<?php
+require 'includes/auth.php';
+require 'includes/db.php';
+require 'includes/csrf.php';
+
+$user_id = $_SESSION['user_id'];
+$offer_id = isset($_GET['offer']) ? intval($_GET['offer']) : 0;
+$error = '';
+$offer = null;
+
+if ($offer_id) {
+    if ($stmt = $conn->prepare('SELECT o.*, l.owner_id FROM trade_offers o JOIN trade_listings l ON o.listing_id = l.id WHERE o.id = ? AND o.status = "accepted"')) {
+        $stmt->bind_param('i', $offer_id);
+        $stmt->execute();
+        $offer = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+    }
+}
+if (!$offer || ($offer['owner_id'] != $user_id && $offer['offerer_id'] != $user_id)) {
+    die('Offer not found.');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_token($_POST['csrf_token'] ?? '')) {
+        $error = 'Invalid CSRF token.';
+    } else {
+        $fulfillment_type = $_POST['fulfillment_type'] ?? '';
+        $shipping_address = null;
+        $meeting_location = null;
+        $tracking_number = null;
+        if ($fulfillment_type === 'ship_to_skuzE') {
+            $shipping_address = trim($_POST['shipping_address'] ?? '');
+            if (!$shipping_address) {
+                $error = 'Shipping address required.';
+            } else {
+                $tracking_number = 'SKZ' . strtoupper(bin2hex(random_bytes(4)));
+                $label = "Ship to: SkuzE Warehouse\n123 SkuzE St\nCity, ST\nTracking: $tracking_number\nFrom:\n$shipping_address\n";
+                if (!is_dir('uploads')) {
+                    mkdir('uploads', 0777, true);
+                }
+                file_put_contents("uploads/label_$offer_id.txt", $label);
+            }
+        } elseif ($fulfillment_type === 'meetup') {
+            $meeting_location = trim($_POST['meeting_location'] ?? '');
+            if (!$meeting_location) {
+                $error = 'Meeting location required.';
+            }
+        } else {
+            $error = 'Invalid fulfillment type.';
+        }
+        if (!$error) {
+            if ($stmt = $conn->prepare('UPDATE trade_offers SET fulfillment_type=?, shipping_address=?, meeting_location=?, tracking_number=? WHERE id=?')) {
+                $stmt->bind_param('ssssi', $fulfillment_type, $shipping_address, $meeting_location, $tracking_number, $offer_id);
+                $stmt->execute();
+                $stmt->close();
+            }
+            header('Location: trade-fulfillment.php?offer=' . $offer_id);
+            exit;
+        }
+    }
+    // reload offer after update or validation
+    if ($stmt = $conn->prepare('SELECT o.*, l.owner_id FROM trade_offers o JOIN trade_listings l ON o.listing_id = l.id WHERE o.id = ?')) {
+        $stmt->bind_param('i', $offer_id);
+        $stmt->execute();
+        $offer = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+    }
+}
+?>
+<?php require 'includes/layout.php'; ?>
+  <meta charset="UTF-8">
+  <title>Fulfillment Details</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <h2>Fulfillment for Offer</h2>
+  <?php if ($error): ?><p class="error"><?= htmlspecialchars($error) ?></p><?php endif; ?>
+  <?php if ($offer['fulfillment_type']): ?>
+    <p>Fulfillment method: <strong><?= htmlspecialchars($offer['fulfillment_type']) ?></strong></p>
+    <?php if ($offer['fulfillment_type'] === 'meetup'): ?>
+      <p>Meeting location: <?= nl2br(htmlspecialchars($offer['meeting_location'])) ?></p>
+    <?php else: ?>
+      <p>Shipping address: <?= nl2br(htmlspecialchars($offer['shipping_address'])) ?></p>
+      <p>Tracking number: <?= htmlspecialchars($offer['tracking_number']) ?></p>
+      <?php $label_file = "uploads/label_{$offer_id}.txt"; if (file_exists($label_file)): ?>
+        <p><a href="<?= htmlspecialchars($label_file) ?>" download>Download Shipping Label</a></p>
+      <?php endif; ?>
+      <p>Please attach the label and drop off your package at your nearest shipping center.</p>
+    <?php endif; ?>
+  <?php else: ?>
+    <form method="post">
+      <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+      <label><input type="radio" name="fulfillment_type" value="meetup" required> Meetup</label>
+      <label><input type="radio" name="fulfillment_type" value="ship_to_skuzE" required> Ship to SkuzE</label>
+      <div id="meetup_fields" style="display:none;">
+        <label>Meeting Location:<br>
+          <input type="text" name="meeting_location" value="<?= htmlspecialchars($_POST['meeting_location'] ?? '') ?>">
+        </label>
+      </div>
+      <div id="ship_fields" style="display:none;">
+        <label>Shipping Address:<br>
+          <textarea name="shipping_address" rows="4" cols="40"><?= htmlspecialchars($_POST['shipping_address'] ?? '') ?></textarea>
+        </label>
+      </div>
+      <button type="submit">Save</button>
+    </form>
+    <script>
+      const radios = document.querySelectorAll('input[name="fulfillment_type"]');
+      const meetup = document.getElementById('meetup_fields');
+      const ship = document.getElementById('ship_fields');
+      function toggleFields() {
+        if (document.querySelector('input[name="fulfillment_type"]:checked')?.value === 'meetup') {
+          meetup.style.display = 'block';
+          ship.style.display = 'none';
+        } else {
+          meetup.style.display = 'none';
+          ship.style.display = 'block';
+        }
+      }
+      radios.forEach(r => r.addEventListener('change', toggleFields));
+      toggleFields();
+    </script>
+  <?php endif; ?>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>

--- a/trade-listing.php
+++ b/trade-listing.php
@@ -1,0 +1,86 @@
+<?php
+require 'includes/auth.php';
+require 'includes/db.php';
+require 'includes/csrf.php';
+
+$user_id = $_SESSION['user_id'];
+$error = '';
+$editing = false;
+$listing = null;
+$edit_id = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
+
+if ($edit_id) {
+    if ($stmt = $conn->prepare('SELECT id, have_item, want_item, status FROM trade_listings WHERE id = ? AND owner_id = ?')) {
+        $stmt->bind_param('ii', $edit_id, $user_id);
+        $stmt->execute();
+        $listing = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        if ($listing) {
+            $editing = true;
+        }
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_token($_POST['csrf_token'] ?? '')) {
+        $error = 'Invalid CSRF token.';
+    } else {
+        $have_item = trim($_POST['have_item'] ?? '');
+        $want_item = trim($_POST['want_item'] ?? '');
+        $status = $_POST['status'] ?? 'open';
+        if ($have_item === '' || $want_item === '') {
+            $error = 'Both fields are required.';
+        }
+        if (!$error) {
+            if ($editing) {
+                if ($stmt = $conn->prepare('UPDATE trade_listings SET have_item=?, want_item=?, status=? WHERE id=? AND owner_id=?')) {
+                    $stmt->bind_param('sssii', $have_item, $want_item, $status, $edit_id, $user_id);
+                    $stmt->execute();
+                    $stmt->close();
+                    header('Location: trade-listings.php');
+                    exit;
+                } else {
+                    $error = 'Database error.';
+                }
+            } else {
+                if ($stmt = $conn->prepare('INSERT INTO trade_listings (owner_id, have_item, want_item, status) VALUES (?,?,?,?)')) {
+                    $stmt->bind_param('isss', $user_id, $have_item, $want_item, $status);
+                    $stmt->execute();
+                    $stmt->close();
+                    header('Location: trade-listings.php');
+                    exit;
+                } else {
+                    $error = 'Database error.';
+                }
+            }
+        }
+    }
+}
+?>
+<?php require 'includes/layout.php'; ?>
+  <meta charset="UTF-8">
+  <title><?= $editing ? 'Edit Trade Listing' : 'New Trade Listing' ?></title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <h2><?= $editing ? 'Edit Listing' : 'Create Trade Listing' ?></h2>
+  <?php if ($error): ?><p class="error"><?= htmlspecialchars($error) ?></p><?php endif; ?>
+  <form method="post">
+    <label>Item You Have:<br><input type="text" name="have_item" value="<?= htmlspecialchars($listing['have_item'] ?? '') ?>" required></label><br>
+    <label>Item You Want:<br><input type="text" name="want_item" value="<?= htmlspecialchars($listing['want_item'] ?? '') ?>" required></label><br>
+    <label>Status:<br>
+      <select name="status">
+        <option value="open" <?= (($listing['status'] ?? '') === 'open') ? 'selected' : '' ?>>Open</option>
+        <option value="accepted" <?= (($listing['status'] ?? '') === 'accepted') ? 'selected' : '' ?>>Accepted</option>
+        <option value="closed" <?= (($listing['status'] ?? '') === 'closed') ? 'selected' : '' ?>>Closed</option>
+      </select>
+    </label><br>
+    <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+    <?php if ($editing): ?><input type="hidden" name="id" value="<?= $edit_id ?>"><?php endif; ?>
+    <button type="submit">Save Listing</button>
+  </form>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>

--- a/trade-listings.php
+++ b/trade-listings.php
@@ -1,0 +1,60 @@
+<?php
+require 'includes/auth.php';
+require 'includes/db.php';
+require 'includes/user.php';
+
+$user_id = $_SESSION['user_id'];
+
+if (isset($_GET['delete'])) {
+    $id = intval($_GET['delete']);
+    if ($stmt = $conn->prepare('DELETE FROM trade_listings WHERE id = ? AND owner_id = ?')) {
+        $stmt->bind_param('ii', $id, $user_id);
+        $stmt->execute();
+        $stmt->close();
+    }
+    header('Location: trade-listings.php');
+    exit;
+}
+
+$sql = 'SELECT tl.id, tl.have_item, tl.want_item, tl.status, tl.owner_id, u.username,
+        (SELECT COUNT(*) FROM trade_offers o WHERE o.listing_id = tl.id AND o.status = "pending") AS pending
+        FROM trade_listings tl JOIN users u ON tl.owner_id = u.id ORDER BY tl.created_at DESC';
+$listings = [];
+if ($result = $conn->query($sql)) {
+    $listings = $result->fetch_all(MYSQLI_ASSOC);
+    $result->close();
+}
+?>
+<?php require 'includes/layout.php'; ?>
+  <meta charset="UTF-8">
+  <title>Trade Listings</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <h2>Trade Listings</h2>
+  <p><a href="trade-listing.php">Create new trade listing</a></p>
+  <table>
+    <tr><th>Have</th><th>Want</th><th>Status</th><th>Owner</th><th>Actions</th></tr>
+    <?php foreach ($listings as $l): ?>
+      <tr>
+        <td><?= htmlspecialchars($l['have_item']) ?></td>
+        <td><?= htmlspecialchars($l['want_item']) ?></td>
+        <td><?= htmlspecialchars($l['status']) ?></td>
+        <td><?= username_with_avatar($conn, $l['owner_id'], $l['username']) ?></td>
+        <td>
+          <?php if ($l['owner_id'] == $user_id): ?>
+            <a href="trade-listing.php?edit=<?= $l['id'] ?>">Edit</a>
+            <a href="trade-listings.php?delete=<?= $l['id'] ?>" onclick="return confirm('Delete listing?');">Delete</a>
+            <a href="trade-offers.php?listing=<?= $l['id'] ?>">Offers (<?= $l['pending'] ?>)</a>
+          <?php elseif ($l['status'] === 'open'): ?>
+            <a href="trade-offer.php?id=<?= $l['id'] ?>">Make Offer</a>
+          <?php endif; ?>
+        </td>
+      </tr>
+    <?php endforeach; ?>
+  </table>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>

--- a/trade-offer.php
+++ b/trade-offer.php
@@ -1,0 +1,67 @@
+<?php
+require 'includes/auth.php';
+require 'includes/db.php';
+require 'includes/csrf.php';
+
+$user_id = $_SESSION['user_id'];
+$listing_id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+$error = '';
+$listing = null;
+
+if ($listing_id) {
+    if ($stmt = $conn->prepare('SELECT tl.id, tl.have_item, tl.want_item, tl.status, tl.owner_id, u.username FROM trade_listings tl JOIN users u ON tl.owner_id = u.id WHERE tl.id = ?')) {
+        $stmt->bind_param('i', $listing_id);
+        $stmt->execute();
+        $listing = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+    }
+}
+
+if (!$listing || $listing['status'] !== 'open' || $listing['owner_id'] == $user_id) {
+    die('Listing not available for offers.');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_token($_POST['csrf_token'] ?? '')) {
+        $error = 'Invalid CSRF token.';
+    } else {
+        $offer_item = trim($_POST['offer_item'] ?? '');
+        $message = trim($_POST['message'] ?? '');
+        if ($offer_item === '') {
+            $error = 'Offer item is required.';
+        }
+        if (!$error) {
+            if ($stmt = $conn->prepare('INSERT INTO trade_offers (listing_id, offerer_id, message, offer_item) VALUES (?,?,?,?)')) {
+                $stmt->bind_param('iiss', $listing_id, $user_id, $message, $offer_item);
+                $stmt->execute();
+                $stmt->close();
+                header('Location: trade-listings.php');
+                exit;
+            } else {
+                $error = 'Database error.';
+            }
+        }
+    }
+}
+?>
+<?php require 'includes/layout.php'; ?>
+  <meta charset="UTF-8">
+  <title>Make Offer</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <h2>Offer Trade to <?= htmlspecialchars($listing['username']) ?></h2>
+  <p>They have: <strong><?= htmlspecialchars($listing['have_item']) ?></strong></p>
+  <p>They want: <strong><?= htmlspecialchars($listing['want_item']) ?></strong></p>
+  <?php if ($error): ?><p class="error"><?= htmlspecialchars($error) ?></p><?php endif; ?>
+  <form method="post">
+    <label>Your Item Offer:<br><input type="text" name="offer_item" required></label><br>
+    <label>Message:<br><textarea name="message"></textarea></label><br>
+    <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+    <button type="submit">Submit Offer</button>
+  </form>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>

--- a/trade-offers.php
+++ b/trade-offers.php
@@ -1,0 +1,110 @@
+<?php
+require 'includes/auth.php';
+require 'includes/db.php';
+require 'includes/csrf.php';
+
+$user_id = $_SESSION['user_id'];
+$listing_id = isset($_GET['listing']) ? intval($_GET['listing']) : 0;
+$error = '';
+$listing = null;
+
+if ($listing_id) {
+    if ($stmt = $conn->prepare('SELECT id, have_item, want_item, status FROM trade_listings WHERE id = ? AND owner_id = ?')) {
+        $stmt->bind_param('ii', $listing_id, $user_id);
+        $stmt->execute();
+        $listing = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+    }
+}
+if (!$listing) {
+    die('Listing not found.');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_token($_POST['csrf_token'] ?? '')) {
+        $error = 'Invalid CSRF token.';
+    } else {
+        $offer_id = intval($_POST['offer_id'] ?? 0);
+        $action = $_POST['action'] ?? '';
+        if ($action === 'accept') {
+            if ($stmt = $conn->prepare('UPDATE trade_offers SET status="accepted" WHERE id=? AND listing_id=?')) {
+                $stmt->bind_param('ii', $offer_id, $listing_id);
+                $stmt->execute();
+                $stmt->close();
+            }
+            if ($stmt = $conn->prepare('UPDATE trade_offers SET status="declined" WHERE listing_id=? AND id<>?')) {
+                $stmt->bind_param('ii', $listing_id, $offer_id);
+                $stmt->execute();
+                $stmt->close();
+            }
+            if ($stmt = $conn->prepare('UPDATE trade_listings SET status="closed" WHERE id=?')) {
+                $stmt->bind_param('i', $listing_id);
+                $stmt->execute();
+                $stmt->close();
+            }
+            header('Location: trade-fulfillment.php?offer=' . $offer_id);
+            exit;
+        } elseif ($action === 'decline') {
+            if ($stmt = $conn->prepare('UPDATE trade_offers SET status="declined" WHERE id=? AND listing_id=?')) {
+                $stmt->bind_param('ii', $offer_id, $listing_id);
+                $stmt->execute();
+                $stmt->close();
+            }
+            header('Location: trade-offers.php?listing=' . $listing_id);
+            exit;
+        }
+        header('Location: trade-offers.php?listing=' . $listing_id);
+        exit;
+    }
+}
+
+$offers = [];
+if ($stmt = $conn->prepare('SELECT o.id, o.offer_item, o.message, o.status, u.username FROM trade_offers o JOIN users u ON o.offerer_id = u.id WHERE o.listing_id = ? ORDER BY o.created_at DESC')) {
+    $stmt->bind_param('i', $listing_id);
+    $stmt->execute();
+    $offers = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+}
+?>
+<?php require 'includes/layout.php'; ?>
+  <meta charset="UTF-8">
+  <title>Offers for Listing</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <h2>Offers for Your Listing</h2>
+  <p>You have: <strong><?= htmlspecialchars($listing['have_item']) ?></strong></p>
+  <p>You want: <strong><?= htmlspecialchars($listing['want_item']) ?></strong></p>
+  <?php if ($error): ?><p class="error"><?= htmlspecialchars($error) ?></p><?php endif; ?>
+  <table>
+    <tr><th>Offerer</th><th>Offer Item</th><th>Message</th><th>Status</th><th>Actions</th></tr>
+    <?php foreach ($offers as $o): ?>
+      <tr>
+        <td><?= htmlspecialchars($o['username']) ?></td>
+        <td><?= htmlspecialchars($o['offer_item']) ?></td>
+        <td><?= htmlspecialchars($o['message']) ?></td>
+        <td><?= htmlspecialchars($o['status']) ?></td>
+        <td>
+          <?php if ($o['status'] === 'pending' && $listing['status'] === 'open'): ?>
+            <form method="post" style="display:inline">
+              <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+              <input type="hidden" name="offer_id" value="<?= $o['id'] ?>">
+              <button type="submit" name="action" value="accept">Accept</button>
+            </form>
+            <form method="post" style="display:inline">
+              <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+              <input type="hidden" name="offer_id" value="<?= $o['id'] ?>">
+              <button type="submit" name="action" value="decline">Decline</button>
+            </form>
+          <?php elseif ($o['status'] === 'accepted'): ?>
+            <a href="trade-fulfillment.php?offer=<?= $o['id'] ?>">View Fulfillment</a>
+          <?php endif; ?>
+        </td>
+      </tr>
+    <?php endforeach; ?>
+  </table>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>

--- a/trade.php
+++ b/trade.php
@@ -4,6 +4,16 @@ require 'includes/db.php';
 require 'includes/csrf.php';
 
 $user_id = $_SESSION['user_id'];
+$is_vip = false;
+if ($stmtVip = $conn->prepare('SELECT vip_status, vip_expires_at FROM users WHERE id=?')) {
+  $stmtVip->bind_param('i', $user_id);
+  $stmtVip->execute();
+  $stmtVip->bind_result($vipStatus, $vipExpires);
+  if ($stmtVip->fetch()) {
+    $is_vip = $vipStatus && (!$vipExpires || strtotime($vipExpires) > time());
+  }
+  $stmtVip->close();
+}
 $edit_id = isset($_GET['edit']) ? (int)$_GET['edit'] : 0;
 $editing = false;
 $request = null;
@@ -52,6 +62,10 @@ if ($stmt) {
 <body>
   <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
+
+  <?php if ($is_vip): ?>
+    <p class="notice">VIP members skip admin approval for trade requests.</p>
+  <?php endif; ?>
 
   <?php if ($db_error): ?>
     <p class="error"><?= htmlspecialchars($db_error) ?></p>

--- a/vip.php
+++ b/vip.php
@@ -1,0 +1,65 @@
+<?php
+require 'includes/auth.php';
+require 'includes/db.php';
+require 'includes/csrf.php';
+
+$user_id = $_SESSION['user_id'];
+$message = '';
+
+// Fetch current VIP status
+$vip = 0;
+$vip_expires = null;
+if ($stmt = $conn->prepare('SELECT vip_status, vip_expires_at FROM users WHERE id=?')) {
+    $stmt->bind_param('i', $user_id);
+    $stmt->execute();
+    $stmt->bind_result($vip, $vip_expires);
+    $stmt->fetch();
+    $stmt->close();
+}
+$vip_active = $vip && (!$vip_expires || strtotime($vip_expires) > time());
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_token($_POST['csrf_token'] ?? '')) {
+        $message = 'Invalid CSRF token.';
+    } else {
+        // In a real app, payment processing would occur here
+        $expires = date('Y-m-d H:i:s', strtotime('+30 days'));
+        if ($stmt = $conn->prepare('UPDATE users SET vip_status=1, vip_expires_at=? WHERE id=?')) {
+            $stmt->bind_param('si', $expires, $user_id);
+            $stmt->execute();
+            $stmt->close();
+            $vip = 1;
+            $vip_expires = $expires;
+            $vip_active = true;
+            $message = 'VIP activated!';
+        }
+    }
+}
+?>
+<?php require 'includes/layout.php'; ?>
+  <title>VIP Membership</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <h2>VIP Membership</h2>
+  <?php if ($message): ?>
+    <p><?= htmlspecialchars($message) ?></p>
+  <?php endif; ?>
+  <?php if ($vip_active): ?>
+    <p>Your VIP membership is active until <?= htmlspecialchars($vip_expires) ?>.</p>
+    <form method="post">
+      <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+      <button type="submit">Renew VIP (30 days)</button>
+    </form>
+  <?php else: ?>
+    <p>Activate VIP to skip approvals and enjoy perks.</p>
+    <form method="post">
+      <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+      <button type="submit">Purchase VIP (30 days)</button>
+    </form>
+  <?php endif; ?>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend `trade_offers` schema with fulfillment fields and tracking numbers
- add fulfillment page that collects meetup or shipping details and generates labels
- redirect accepted offers to fulfillment and expose link to view details
- link promoted shops page and add configurable AdSense support
- add toolbox page backed by JSON with admin management
- add business account support with schema, registration, profile upgrade, and business metadata display
- extend `users` schema with VIP fields and auto-approval rules
- provide VIP purchase page with badges and renewal reminders

## Testing
- `php -l vip.php sell.php submit-request.php dashboard.php includes/user.php includes/sidebar.php view-profile.php trade.php trade-listings.php`
- `php -l trade-fulfillment.php trade-offers.php trade-offer.php trade-listing.php promoted.php config.example.php admin/toolbox.php toolbox.php admin/index.php register.php profile.php`
- `jq . assets/tools.json`


------
https://chatgpt.com/codex/tasks/task_e_68afd440fa88832b8a52ccb98125437b