### PR TITLE
Uppercase interface text, enhance theme editor, and nest thread replies

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -10,3 +10,4 @@
   tracking of failed login attempts by IP, enforcing rate limits across sessions.
 - Run migration `migrations/013_create_service_requests.sql` in all environments to create the `service_requests` table,
   which stores device service requests.
+- Ensure `assets/themes.json` is deployed and readable by the web server so the client can load theme definitions.

--- a/admin/discount-codes.php
+++ b/admin/discount-codes.php
@@ -50,7 +50,7 @@ $codes = $result ? $result->fetch_all(MYSQLI_ASSOC) : [];
   <?php include '../includes/header.php'; ?>
   <h2>Discount Codes</h2>
   <?php if (!empty($error)) echo "<p style='color:red;'>" . htmlspecialchars($error) . "</p>"; ?>
-  <p><a href="index.php">Back to Admin Panel</a></p>
+  <p><a class="btn" href="index.php">Back to Admin Panel</a></p>
   <form method="post">
     <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
     <h3>Create Code</h3>

--- a/admin/index.php
+++ b/admin/index.php
@@ -22,13 +22,13 @@ $requests = $stmt->fetch_all(MYSQLI_ASSOC);
 <body>
   <?php include '../includes/header.php'; ?>
   <h2>Admin Panel</h2>
-  <p><a href="listings.php">Review Listings</a></p>
-  <p><a href="trade-requests.php">Review Trade Requests</a></p>
-  <p><a href="discount-codes.php">Manage Discount Codes</a></p>
-  <p><a href="users.php">Manage Users</a></p>
-  <p><a href="theme.php">Vaporwave Theme Settings</a></p>
-  <p><a href="toolbox.php">Manage Toolbox</a></p>
-  <p><a href="../dashboard.php">Back to Dashboard</a></p>
+  <p><a class="btn" href="listings.php">Review Listings</a></p>
+  <p><a class="btn" href="trade-requests.php">Review Trade Requests</a></p>
+  <p><a class="btn" href="discount-codes.php">Manage Discount Codes</a></p>
+  <p><a class="btn" href="users.php">Manage Users</a></p>
+  <p><a class="btn" href="theme.php">Vaporwave Theme Settings</a></p>
+  <p><a class="btn" href="toolbox.php">Manage Toolbox</a></p>
+  <p><a class="btn" href="../dashboard.php">Back to Dashboard</a></p>
 
   <table>
     <thead>

--- a/admin/listings.php
+++ b/admin/listings.php
@@ -44,7 +44,7 @@ $listings = $result ? $result->fetch_all(MYSQLI_ASSOC) : [];
   <?php include '../includes/header.php'; ?>
   <h2>Listings Review</h2>
   <?php if (!empty($error)) echo "<p style='color:red;'>" . htmlspecialchars($error) . "</p>"; ?>
-  <p><a href="index.php">Back to Admin Panel</a></p>
+  <p><a class="btn" href="index.php">Back to Admin Panel</a></p>
   <table>
     <tr><th>ID</th><th>User</th><th>Title</th><th>Price</th><th>Status</th><th>Actions</th></tr>
     <?php foreach ($listings as $l): ?>

--- a/admin/theme.php
+++ b/admin/theme.php
@@ -15,6 +15,12 @@ if (file_exists($themesFile)) {
   }
 }
 
+$gradientPresets = [
+  'vibrant' => 'linear-gradient(135deg, #ff71ce 0%, #01cdfe 100%)',
+  'dark'    => 'linear-gradient(135deg, #2d1e59 0%, #09002e 100%)',
+  'pastel'  => 'linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%)',
+];
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $name = strtolower(preg_replace('/[^a-z0-9_-]/i', '', $_POST['name'] ?? ''));
   if ($name) {
@@ -30,12 +36,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         '--vap3' => $_POST['vap3'] ?? null,
       ],
     ];
-    $freq = $_POST['pattern_freq'] ?? '';
-    $amp = $_POST['pattern_amp'] ?? '';
-    $poly = $_POST['pattern_poly'] ?? '';
-    $hue = $_POST['pattern_hue'] ?? '';
-    $sat = $_POST['pattern_sat'] ?? '';
-    if ($freq !== '' || $amp !== '' || $poly !== '' || $hue !== '' || $sat !== '') {
+    if (!empty($_POST['pattern_enabled'])) {
+      $freq = $_POST['pattern_freq'] ?? '';
+      $amp = $_POST['pattern_amp'] ?? '';
+      $poly = $_POST['pattern_poly'] ?? '';
+      $hue = $_POST['pattern_hue'] ?? '';
+      $sat = $_POST['pattern_sat'] ?? '';
       $themes[$name]['pattern'] = [
         'frequency' => (float)$freq,
         'amplitude' => (float)$amp,
@@ -44,7 +50,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'sat' => (int)$sat,
       ];
     }
-    file_put_contents($themesFile, json_encode($themes, JSON_PRETTY_PRINT));
+    $saved = file_put_contents($themesFile, json_encode($themes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    if ($saved !== false) {
+      // ensure the JSON file remains web accessible
+      @chmod($themesFile, 0644);
+      clearstatcache(true, $themesFile);
+      if (!is_readable($themesFile)) {
+        error_log('themes.json is not readable by the web server');
+      }
+    }
   }
   header('Location: theme.php');
   exit;
@@ -75,9 +89,17 @@ $current = $themes[$edit] ?? null;
     <label>Accent Color
       <input type="color" name="accent" value="<?= htmlspecialchars($current['vars']['--accent'] ?? '#ff71ce', ENT_QUOTES, 'UTF-8'); ?>">
     </label>
-    <label>Gradient CSS
-      <input type="text" name="gradient" value="<?= htmlspecialchars($current['vars']['--gradient'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
-    </label>
+    <div>
+      <span>Gradient</span>
+      <div class="gradient-presets">
+        <?php foreach ($gradientPresets as $grad): ?>
+          <button type="button" class="gradient-preset" data-gradient="<?= htmlspecialchars($grad, ENT_QUOTES, 'UTF-8'); ?>" style="background: <?= htmlspecialchars($grad, ENT_QUOTES, 'UTF-8'); ?>;"></button>
+        <?php endforeach; ?>
+      </div>
+      <label>Custom Gradient (optional)
+        <input type="text" id="gradient" name="gradient" value="<?= htmlspecialchars($current['vars']['--gradient'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+      </label>
+    </div>
     <label>Vap Color 1
       <input type="color" name="vap1" value="<?= htmlspecialchars($current['vars']['--vap1'] ?? '#ff71ce', ENT_QUOTES, 'UTF-8'); ?>">
     </label>
@@ -87,24 +109,31 @@ $current = $themes[$edit] ?? null;
     <label>Vap Color 3
       <input type="color" name="vap3" value="<?= htmlspecialchars($current['vars']['--vap3'] ?? '#05ffa1', ENT_QUOTES, 'UTF-8'); ?>">
     </label>
-    <label>Pattern Frequency
-      <input type="number" step="0.1" name="pattern_freq" value="<?= htmlspecialchars($current['pattern']['frequency'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
-    </label>
-    <label>Pattern Amplitude
-      <input type="number" step="0.1" name="pattern_amp" value="<?= htmlspecialchars($current['pattern']['amplitude'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
-    </label>
-    <label>Pattern Polynomial (comma-separated)
-      <input type="text" name="pattern_poly" value="<?= htmlspecialchars(isset($current['pattern']['poly']) ? implode(',', $current['pattern']['poly']) : '', ENT_QUOTES, 'UTF-8'); ?>">
-    </label>
-    <label>Pattern Hue
-      <input type="number" name="pattern_hue" value="<?= htmlspecialchars($current['pattern']['hue'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
-    </label>
-    <label>Pattern Saturation
-      <input type="number" name="pattern_sat" value="<?= htmlspecialchars($current['pattern']['sat'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
-    </label>
+    <label><input type="checkbox" id="pattern_toggle" name="pattern_enabled" <?= isset($current['pattern']) ? 'checked' : ''; ?>> Enable Pattern</label>
+    <div id="pattern_settings" style="display: <?= isset($current['pattern']) ? 'block' : 'none'; ?>;">
+      <label>Pattern Frequency
+        <input type="range" min="0" max="10" step="0.1" id="pattern_freq" name="pattern_freq" value="<?= htmlspecialchars($current['pattern']['frequency'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>">
+        <span id="pattern_freq_val"></span>
+      </label>
+      <label>Pattern Amplitude
+        <input type="range" min="0" max="10" step="0.1" id="pattern_amp" name="pattern_amp" value="<?= htmlspecialchars($current['pattern']['amplitude'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>">
+        <span id="pattern_amp_val"></span>
+      </label>
+      <label>Pattern Polynomial (comma-separated)
+        <input type="text" id="pattern_poly" name="pattern_poly" value="<?= htmlspecialchars(isset($current['pattern']['poly']) ? implode(',', $current['pattern']['poly']) : '', ENT_QUOTES, 'UTF-8'); ?>">
+      </label>
+      <label>Pattern Hue
+        <input type="range" min="0" max="360" id="pattern_hue" name="pattern_hue" value="<?= htmlspecialchars($current['pattern']['hue'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>">
+        <span id="pattern_hue_val"></span>
+      </label>
+      <label>Pattern Saturation
+        <input type="range" min="0" max="100" id="pattern_sat" name="pattern_sat" value="<?= htmlspecialchars($current['pattern']['sat'] ?? '100', ENT_QUOTES, 'UTF-8'); ?>">
+        <span id="pattern_sat_val"></span>
+      </label>
+    </div>
     <button type="submit">Save Theme</button>
   </form>
-  <p><a href="theme.php">Back</a></p>
+  <p><a class="btn" href="theme.php">Back</a></p>
 <?php else: ?>
   <ul>
     <?php foreach ($themes as $name => $t): ?>
@@ -128,13 +157,23 @@ $current = $themes[$edit] ?? null;
     <label>Accent Color
       <input type="color" name="accent" value="#ff71ce">
     </label>
-    <label>Gradient CSS
-      <input type="text" name="gradient" value="linear-gradient(135deg, #ff71ce 0%, #01cdfe 100%)">
-    </label>
+    <div>
+      <span>Gradient</span>
+      <div class="gradient-presets">
+        <?php foreach ($gradientPresets as $grad): ?>
+          <button type="button" class="gradient-preset" data-gradient="<?= htmlspecialchars($grad, ENT_QUOTES, 'UTF-8'); ?>" style="background: <?= htmlspecialchars($grad, ENT_QUOTES, 'UTF-8'); ?>;"></button>
+        <?php endforeach; ?>
+      </div>
+      <label>Custom Gradient (optional)
+        <input type="text" id="gradient" name="gradient" value="linear-gradient(135deg, #ff71ce 0%, #01cdfe 100%)">
+      </label>
+    </div>
     <button type="submit">Create Theme</button>
   </form>
 <?php endif; ?>
-  <p><a href="index.php">Back to Admin Panel</a></p>
+  <p><a class="btn" href="index.php">Back to Admin Panel</a></p>
+  <script src="../assets/admin-pattern.js"></script>
+  <script src="../assets/admin-theme.js"></script>
   <?php include '../includes/footer.php'; ?>
 </body>
 </html>

--- a/admin/toolbox.php
+++ b/admin/toolbox.php
@@ -119,7 +119,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       </tr>
     </tbody>
   </table>
-  <p><a href="../toolbox.php">View Toolbox</a></p>
+  <p><a class="btn" href="../toolbox.php">View Toolbox</a></p>
   <?php include '../includes/footer.php'; ?>
 </body>
 </html>

--- a/admin/trade-requests.php
+++ b/admin/trade-requests.php
@@ -22,7 +22,7 @@ $requests = $stmt->fetch_all(MYSQLI_ASSOC);
 <body>
   <?php include '../includes/header.php'; ?>
   <h2>Trade Requests</h2>
-  <p><a href="index.php">Back to Admin Panel</a></p>
+  <p><a class="btn" href="index.php">Back to Admin Panel</a></p>
   <table>
     <thead>
       <tr>

--- a/admin/user-edit.php
+++ b/admin/user-edit.php
@@ -90,7 +90,7 @@ if ($stmt) {
     </label><br>
     <button type="submit">Save</button>
   </form>
-  <p><a href="users.php">Back to Users</a></p>
+  <p><a class="btn" href="users.php">Back to Users</a></p>
   <?php include '../includes/footer.php'; ?>
 </body>
 </html>

--- a/admin/view.php
+++ b/admin/view.php
@@ -93,7 +93,7 @@ $online_status = $is_online ? "<span style='color:green;'>Online</span>" : "<spa
 
     <button type="submit">Save Changes</button>
   </form>
-  <p><a href="index.php">← Back to All Requests</a></p>
+  <p><a class="btn" href="index.php">← Back to All Requests</a></p>
   <?php include '../includes/footer.php'; ?>
 </body>
 </html>

--- a/assets/admin-theme.js
+++ b/assets/admin-theme.js
@@ -1,0 +1,72 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.documentElement;
+  const form = document.querySelector('form');
+  if (!form) return;
+
+  const gradientInput = document.getElementById('gradient');
+  document.querySelectorAll('.gradient-preset').forEach(btn => {
+    btn.addEventListener('click', () => {
+      gradientInput.value = btn.dataset.gradient;
+      document.querySelectorAll('.gradient-preset').forEach(b => b.classList.remove('selected'));
+      btn.classList.add('selected');
+      preview();
+    });
+    if (gradientInput && gradientInput.value === btn.dataset.gradient) {
+      btn.classList.add('selected');
+    }
+  });
+
+  form.querySelectorAll('input[type="range"]').forEach(inp => {
+    const display = document.getElementById(inp.id + '_val');
+    const update = () => { if (display) display.textContent = inp.value; };
+    inp.addEventListener('input', update);
+    update();
+  });
+
+  const patternToggle = document.getElementById('pattern_toggle');
+  const patternSettings = document.getElementById('pattern_settings');
+  if (patternToggle && patternSettings) {
+    patternToggle.addEventListener('change', () => {
+      patternSettings.style.display = patternToggle.checked ? 'block' : 'none';
+      preview();
+    });
+  }
+
+  function preview() {
+    const bg = form.querySelector('[name="bg"]');
+    const fg = form.querySelector('[name="fg"]');
+    const accent = form.querySelector('[name="accent"]');
+    if (bg) root.style.setProperty('--bg', bg.value);
+    if (fg) root.style.setProperty('--fg', fg.value);
+    if (accent) root.style.setProperty('--accent', accent.value);
+    if (gradientInput) root.style.setProperty('--gradient', gradientInput.value);
+    ['vap1', 'vap2', 'vap3'].forEach(v => {
+      const el = form.querySelector(`[name="${v}"]`);
+      if (el) root.style.setProperty(`--${v}`, el.value);
+    });
+    if (patternToggle && patternToggle.checked) {
+      const s = {
+        frequency: form.pattern_freq.value,
+        amplitude: form.pattern_amp.value,
+        poly: form.pattern_poly.value.split(',').map(Number).filter(n => !isNaN(n)),
+        hue: form.pattern_hue.value,
+        sat: form.pattern_sat.value,
+      };
+      if (window.generateVaporwavePattern) {
+        window.generateVaporwavePattern(s);
+      }
+    } else if (window.generateVaporwavePattern) {
+      window.generateVaporwavePattern(null);
+    }
+  }
+
+  form.querySelectorAll('input').forEach(inp => inp.addEventListener('input', preview));
+  preview();
+
+  form.addEventListener('submit', e => {
+    if (gradientInput && gradientInput.value.trim() && !CSS.supports('background', gradientInput.value)) {
+      alert('Invalid gradient CSS');
+      e.preventDefault();
+    }
+  });
+});

--- a/assets/style.css
+++ b/assets/style.css
@@ -292,6 +292,7 @@ footer:hover {
   perspective: 500px;
   transform: perspective(500px) translateZ(0);
   transition: transform 0.2s, box-shadow 0.2s;
+  text-transform: uppercase;
 }
 
 .site-header::before {
@@ -308,6 +309,24 @@ footer:hover {
 .site-header:hover {
   transform: perspective(500px) translateZ(var(--header-depth));
   box-shadow: 0 4px var(--header-depth) rgba(0, 0, 0, 0.6), 0 -4px var(--header-depth) rgba(255, 255, 255, 0.2);
+}
+
+.header-left,
+.header-center,
+.header-right {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.header-left,
+.header-right {
+  flex: 1;
+}
+
+.header-center {
+  flex: 1;
+  justify-content: center;
 }
 
 .logo-img {
@@ -334,6 +353,7 @@ footer:hover {
   box-shadow: 0 2px 0 rgba(0, 0, 0, 0.4);
   transform: perspective(300px) translateZ(0);
   transition: background 0.2s, transform 0.1s, box-shadow 0.1s;
+  text-transform: uppercase;
 }
 
 .site-nav a:hover {
@@ -347,6 +367,25 @@ footer:hover {
   background: #444;
   transform: perspective(300px) translateZ(2px);
   box-shadow: inset 0 2px 0 rgba(0, 0, 0, 0.4);
+}
+
+@media (max-width: 600px) {
+  .site-header {
+    flex-direction: column;
+  }
+
+  .header-left,
+  .header-center,
+  .header-right {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .header-left ul,
+  .header-right ul {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
 }
 
 /* Forms and buttons */
@@ -620,6 +659,7 @@ tbody tr:nth-child(even) {
 .side-nav-title {
   margin: 0 1rem 0.5rem;
   font-weight: 600;
+  text-transform: uppercase;
 }
 
 .side-nav ul {
@@ -675,6 +715,11 @@ tbody tr:nth-child(even) {
   margin: 0.5rem 0;
 }
 
+.conversation-list .btn {
+  display: block;
+  width: 100%;
+}
+
 .message-thread {
   margin-bottom: 1rem;
 }
@@ -691,15 +736,33 @@ tbody tr:nth-child(even) {
 
 /* Forum posts */
 .post {
-  border-left: 2px solid var(--accent);
-  padding-left: 10px;
-  margin: 1rem 0;
+  margin-bottom: 0.5rem;
 }
 
-.post .post {
-  margin-left: 20px;
+.post-children {
+  margin-left: 1rem;
+  padding-left: 0.5rem;
+  border-left: 2px solid var(--accent);
 }
 
 .inline-reply {
   margin-top: 0.5rem;
+}
+
+.gradient-presets {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+.gradient-preset {
+  width: 40px;
+  height: 40px;
+  border: 2px solid #fff;
+  cursor: pointer;
+  outline: none;
+}
+
+.gradient-preset.selected {
+  outline: 2px solid var(--accent);
 }

--- a/assets/theme-toggle.js
+++ b/assets/theme-toggle.js
@@ -42,19 +42,25 @@ function buildOptions() {
 async function initThemes() {
   try {
     const res = await fetch('/assets/themes.json');
-    themes = await res.json();
-    buildOptions();
-    const stored = localStorage.getItem('theme');
-    if (stored && themes[stored]) {
-      applyTheme(stored);
-    } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches && themes['dark']) {
-      applyTheme('dark');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if (data && typeof data === 'object' && !Array.isArray(data)) {
+      themes = data;
     } else {
-      const first = Object.keys(themes)[0];
-      if (first) applyTheme(first);
+      throw new Error('Invalid theme JSON');
     }
   } catch (e) {
     console.error('Theme load failed', e);
+  }
+  buildOptions();
+  const stored = localStorage.getItem('theme');
+  if (stored && themes[stored]) {
+    applyTheme(stored);
+  } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches && themes['dark']) {
+    applyTheme('dark');
+  } else {
+    const first = Object.keys(themes)[0];
+    if (first) applyTheme(first);
   }
 }
 

--- a/forum/thread.php
+++ b/forum/thread.php
@@ -63,13 +63,13 @@ if ($pst = $conn->prepare("SELECT fp.id, fp.parent_id, fp.content, fp.created_at
   $pst->close();
 }
 
-function render_posts($parent_id = 0) {
+function render_posts($parent_id = 0, $depth = 0) {
   global $posts_by_parent, $conn, $thread_id;
   if (empty($posts_by_parent[$parent_id])) {
     return;
   }
   foreach ($posts_by_parent[$parent_id] as $post) {
-    echo '<div class="post">';
+    echo '<div class="post level-' . $depth . '">';
     echo '<strong>' . username_with_avatar($conn, $post['user_id'], $post['username']) . '</strong> on ' . htmlspecialchars($post['created_at']);
     echo '<p>' . nl2br(htmlspecialchars($post['content'])) . '</p>';
     echo '<form method="get" action="thread.php#reply-form" class="inline-reply">';
@@ -77,7 +77,11 @@ function render_posts($parent_id = 0) {
     echo '<input type="hidden" name="reply_to" value="' . $post['id'] . '">';
     echo '<button type="submit" aria-label="Reply to this post">Reply</button>';
     echo '</form>';
-    render_posts($post['id']);
+    if (!empty($posts_by_parent[$post['id']])) {
+      echo '<div class="post-children">';
+      render_posts($post['id'], $depth + 1);
+      echo '</div>';
+    }
     echo '</div>';
   }
 }

--- a/includes/header.php
+++ b/includes/header.php
@@ -36,14 +36,21 @@ if (!empty($_SESSION['user_id'])) {
   }
 ?>
 <header class="site-header">
-  <a href="/index.php" class="logo-link">
-    <img class="logo-img" src="/assets/logo.png" alt="SkuzE Logo">
-  </a>
-  <nav class="site-nav">
+  <nav class="site-nav header-left">
+    <a href="/index.php" class="logo-link">
+      <img class="logo-img" src="/assets/logo.png" alt="SkuzE Logo">
+    </a>
     <ul>
       <li><a href="/index.php">Home</a></li>
       <li><a href="/about.php">About</a></li>
       <li><a href="/help.php">Help/FAQ</a></li>
+    </ul>
+  </nav>
+  <form class="site-search header-center" action="/search.php" method="get">
+    <input type="text" name="q" placeholder="Search..." value="<?= htmlspecialchars($_GET['q'] ?? '') ?>">
+  </form>
+  <nav class="site-nav header-right">
+    <ul>
 <?php if (empty($_SESSION['user_id'])): ?>
       <li><a href="/login.php">Login</a></li>
       <li><a href="/register.php">Register</a></li>
@@ -52,16 +59,11 @@ if (!empty($_SESSION['user_id'])) {
       <li><a href="/notifications.php">Notifications<?php if (!empty($unread_notifications)): ?><span class="badge"><?= $unread_notifications ?></span><?php endif; ?></a></li>
       <li><a href="/messages.php">Messages<?php if (!empty($unread_messages)): ?><span class="badge"><?= $unread_messages ?></span><?php endif; ?></a></li>
       <li><a href="/logout.php">Logout</a></li>
+      <li class="user-info"><?= username_with_avatar($conn, $_SESSION['user_id'], $username) ?></li>
 <?php endif; ?>
+      <li><button id="theme-toggle" type="button" aria-haspopup="dialog" aria-controls="theme-modal">Themes</button></li>
     </ul>
   </nav>
-  <?php if (!empty($_SESSION['user_id'])): ?>
-    <?= username_with_avatar($conn, $_SESSION['user_id'], $username) ?>
-  <?php endif; ?>
-  <form class="site-search" action="/search.php" method="get">
-    <input type="text" name="q" placeholder="Search..." value="<?= htmlspecialchars($_GET['q'] ?? '') ?>">
-  </form>
-  <button id="theme-toggle" type="button" aria-haspopup="dialog" aria-controls="theme-modal">Themes</button>
 </header>
 <div id="theme-modal" class="theme-modal" role="dialog" aria-modal="true" hidden tabindex="-1">
   <div class="modal-content">

--- a/messages.php
+++ b/messages.php
@@ -32,7 +32,7 @@ $stmt->close();
     <ul class="conversation-list">
       <?php foreach ($conversations as $c): ?>
         <li>
-          <a href="message-thread.php?user=<?= $c['other_id'] ?>">
+          <a class="btn" href="message-thread.php?user=<?= $c['other_id'] ?>">
             <?= htmlspecialchars($c['username']) ?>
             <?php if ($c['unread'] > 0): ?>
               <span class="badge"><?= $c['unread'] ?></span>


### PR DESCRIPTION
## Summary
- Make site header text uppercase
- Uppercase navigation links and side navigation titles
- Scope styling to interface elements to avoid altering user-generated content
- Split header into left/center/right sections and add user nav on the right
- Apply flexbox styling with responsive stacking for new header layout
- Replace theme editor inputs with sliders, gradient presets, and pattern toggle
- Add live theme preview and client-side validation in admin panel
- Nest thread replies in `post-children` containers with depth classes for fine‑grained indentation
- Tighten post spacing and add CSS for Reddit-style threading
- Save `themes.json` with web-server readable permissions and validate it when loading themes
- Style conversation and admin navigation links with 3D `.btn` buttons

## Testing
- `php -l messages.php`
- `php -l admin/index.php`
- `php -l admin/trade-requests.php`
- `php -l admin/discount-codes.php`
- `php -l admin/theme.php`
- `php -l admin/user-edit.php`
- `php -l admin/toolbox.php`
- `php -l admin/listings.php`
- `php -l admin/view.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b11be20334832bbba9875e9219d6fd