### PR TITLE
Add base_url helper, update checkout URLs, and verify required extensions

### DIFF
--- a/checkout.php
+++ b/checkout.php
@@ -1,6 +1,8 @@
 <?php
+require 'includes/requirements.php';
 require 'includes/auth.php';
 require 'includes/db.php';
+require 'includes/url.php';
 
 // Load Stripe secret from config file if present or fallback to environment variable
 $stripeSecret = null;
@@ -66,8 +68,15 @@ if ($code !== '') {
     } else {
       die('Invalid discount code.');
     }
-    $stmt->close();
+  $stmt->close();
   }
+}
+
+$successUrl = base_url('/success.php');
+$cancelUrl = base_url('/cancel.php');
+
+if (!filter_var($successUrl, FILTER_VALIDATE_URL) || !filter_var($cancelUrl, FILTER_VALIDATE_URL)) {
+  die('Invalid redirect URL.');
 }
 
 $session = \Stripe\Checkout\Session::create([
@@ -81,8 +90,8 @@ $session = \Stripe\Checkout\Session::create([
     'quantity' => 1,
   ]],
   'mode' => 'payment',
-  'success_url' => 'success.php',
-  'cancel_url' => 'cancel.php',
+  'success_url' => $successUrl,
+  'cancel_url' => $cancelUrl,
 ]);
 
 header("Location: " . $session->url);

--- a/includes/requirements.php
+++ b/includes/requirements.php
@@ -1,0 +1,15 @@
+<?php
+$requiredExtensions = ['curl', 'json', 'mbstring', 'openssl', 'mysqli'];
+$missing = [];
+foreach ($requiredExtensions as $ext) {
+  if (!extension_loaded($ext)) {
+    $missing[] = $ext;
+  }
+}
+if ($missing) {
+  $message = 'Missing PHP extensions: ' . implode(', ', $missing) .
+    ". Enable them in cPanel's \"Select PHP Version\" interface.";
+  error_log($message);
+  die($message);
+}
+

--- a/includes/url.php
+++ b/includes/url.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Generate the base URL for the application.
+ *
+ * The scheme is detected using X-Forwarded-Proto and HTTPS/port checks
+ * with a final enforcement to https.
+ * The host is taken from X-Forwarded-Host or HTTP_HOST.
+ *
+ * @param string $path Optional path to append.
+ * @return string
+ */
+function base_url(string $path = ''): string
+{
+    $scheme = 'http';
+    if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+        $scheme = strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']);
+    } elseif (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+        $scheme = 'https';
+    } elseif (!empty($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443) {
+        $scheme = 'https';
+    }
+
+    // Always enforce https
+    $scheme = 'https';
+
+    $host = $_SERVER['HTTP_X_FORWARDED_HOST'] ?? ($_SERVER['HTTP_HOST'] ?? '');
+    $base = $scheme . '://' . $host;
+
+    if ($path !== '') {
+        $base .= '/' . ltrim($path, '/');
+    }
+
+    return $base;
+}


### PR DESCRIPTION
## Summary
- add base_url helper using forwarded headers and enforce https
- use base_url for Stripe success and cancel URLs
- validate generated redirect URLs before creating Stripe checkout sessions
- check for required PHP extensions and prompt enabling them via cPanel

## Testing
- `php -l includes/requirements.php checkout.php includes/url.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3cd53a9b4832b81565637b6ed35e4