### PR TITLE
Integrate basic Square checkout flow

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -11,3 +11,9 @@
 - Run migration `migrations/013_create_service_requests.sql` in all environments to create the `service_requests` table,
   which stores device service requests.
 - Ensure `assets/themes.json` is deployed and readable by the web server so the client can load theme definitions.
+- Run `schema/payments.sql` in all environments to create the `payments` table for recording Square transactions.
+- Configure Square payment credentials in `config.php` (or via environment variables):
+  - `square_application_id`
+  - `square_location_id`
+  - `square_access_token`
+  - `square_environment` (`sandbox` or `production`)

--- a/assets/checkout.js
+++ b/assets/checkout.js
@@ -1,0 +1,35 @@
+// Square Web Payments entry point for checkout
+
+async function initSquare() {
+  const container = document.getElementById('card-container');
+  if (!container || !window.Square) {
+    console.error('Square.js failed to load.');
+    return;
+  }
+
+  const appId = container.dataset.appId;
+  const locationId = container.dataset.locationId;
+  const payments = window.Square.payments(appId, locationId);
+  const card = await payments.card();
+  await card.attach('#card-container');
+
+  const form = document.getElementById('payment-form');
+  form.addEventListener('submit', async function (e) {
+    e.preventDefault();
+    try {
+      const result = await card.tokenize();
+      if (result.status === 'OK') {
+        document.getElementById('token').value = result.token;
+        form.submit();
+      } else {
+        const message = result.errors && result.errors[0] ? result.errors[0].message : 'Tokenization failed';
+        alert(message);
+      }
+    } catch (err) {
+      console.error(err);
+      alert('An unexpected error occurred');
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initSquare);

--- a/checkout.php
+++ b/checkout.php
@@ -3,10 +3,54 @@ require 'includes/requirements.php';
 require 'includes/auth.php';
 require 'includes/db.php';
 require 'includes/url.php';
+require 'includes/square.php';
 
-// Placeholder for future payment integration.
-// TODO: integrate a provider such as Square.
-http_response_code(503);
-echo 'Payments are temporarily unavailable.';
-exit;
+$listing_id = isset($_GET['listing_id']) ? intval($_GET['listing_id']) : 0;
+if (!$listing_id) {
+    header('Location: buy.php');
+    exit;
+}
 
+// Fetch the listing details
+$stmt = $conn->prepare('SELECT id, title, description, price FROM listings WHERE id = ? LIMIT 1');
+$stmt->bind_param('i', $listing_id);
+$stmt->execute();
+$result = $stmt->get_result();
+$listing = $result->fetch_assoc();
+$stmt->close();
+
+if (!$listing) {
+    http_response_code(404);
+    echo 'Listing not found';
+    exit;
+}
+
+$applicationId = $squareConfig['application_id'];
+$locationId = $squareConfig['location_id'];
+$environment = $squareConfig['environment'];
+$squareJs = $environment === 'production'
+    ? 'https://web.squarecdn.com/v1/square.js'
+    : 'https://sandbox.web.squarecdn.com/v1/square.js';
+?>
+<?php require 'includes/layout.php'; ?>
+  <title>Checkout</title>
+  <link rel="stylesheet" href="assets/style.css">
+  <script src="<?= $squareJs; ?>"></script>
+  <script src="assets/checkout.js" defer></script>
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <h2>Checkout</h2>
+  <h3><?= htmlspecialchars($listing['title']); ?></h3>
+  <p><?= nl2br(htmlspecialchars($listing['description'])); ?></p>
+  <p class="price">$<?= htmlspecialchars($listing['price']); ?></p>
+  <form id="payment-form" method="post" action="checkout_process.php">
+    <div id="card-container" data-app-id="<?= htmlspecialchars($applicationId); ?>" data-location-id="<?= htmlspecialchars($locationId); ?>"></div>
+    <input type="hidden" name="token" id="token">
+    <input type="hidden" name="listing_id" value="<?= $listing['id']; ?>">
+    <button type="submit">Pay Now</button>
+  </form>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>

--- a/checkout_process.php
+++ b/checkout_process.php
@@ -1,0 +1,66 @@
+<?php
+require 'includes/requirements.php';
+require 'includes/auth.php';
+require 'includes/db.php';
+require 'includes/url.php';
+require 'includes/square.php';
+
+$token = $_POST['token'] ?? '';
+$listing_id = isset($_POST['listing_id']) ? intval($_POST['listing_id']) : 0;
+
+if (!$token || !$listing_id) {
+    header('Location: cancel.php');
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT price FROM listings WHERE id = ? LIMIT 1');
+$stmt->bind_param('i', $listing_id);
+$stmt->execute();
+$stmt->bind_result($price);
+if (!$stmt->fetch()) {
+    $stmt->close();
+    header('Location: cancel.php');
+    exit;
+}
+$stmt->close();
+
+$amount = (int)round($price * 100);
+
+use Square\Exceptions\ApiException;
+use Square\Models\CreatePaymentRequest;
+use Square\Models\Money;
+
+$paymentsApi = $square->getPaymentsApi();
+
+$money = new Money();
+$money->setAmount($amount);
+$money->setCurrency('USD');
+
+$paymentRequest = new CreatePaymentRequest(uniqid('', true), $token);
+$paymentRequest->setAmountMoney($money);
+$paymentRequest->setLocationId($squareConfig['location_id']);
+
+try {
+    $apiResponse = $paymentsApi->createPayment($paymentRequest);
+    $result = $apiResponse->getResult();
+    $status = $result->getPayment()->getStatus();
+    $paymentId = $result->getPayment()->getId();
+} catch (ApiException $e) {
+    $status = 'FAILED';
+    $paymentId = null;
+}
+
+if ($stmt = $conn->prepare('INSERT INTO payments (user_id, listing_id, amount, payment_id, status) VALUES (?,?,?,?,?)')) {
+    $stmt->bind_param('iiiss', $user_id, $listing_id, $amount, $paymentId, $status);
+    $stmt->execute();
+    $stmt->close();
+}
+
+if ($status === 'COMPLETED') {
+    header('Location: success.php');
+    exit;
+}
+
+header('Location: cancel.php');
+exit;
+?>

--- a/config.example.php
+++ b/config.example.php
@@ -14,6 +14,13 @@ return [
 
   // Google AdSense configuration
   'adsense_client' => 'ca-pub-XXXXXXXXXXXXXXXX',
-  'adsense_slot' => '1234567890'
-  // TODO: Square payment configuration goes here
+  'adsense_slot' => '1234567890',
+
+  // Square payment configuration
+  // These can also be supplied via env vars:
+  // SQUARE_APPLICATION_ID, SQUARE_LOCATION_ID, SQUARE_ACCESS_TOKEN, SQUARE_ENVIRONMENT
+  'square_application_id' => 'sandbox-sq0idb-xxxxxxxxxxxxxxxxxxxxxx',
+  'square_location_id' => 'LXXXXXXXXXXXX',
+  'square_access_token' => 'EAAAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+  'square_environment' => 'sandbox', // or 'production'
 ];

--- a/includes/square.php
+++ b/includes/square.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Square helper.
+ *
+ * Loads credentials from config.php or environment variables, instantiates
+ * Square\SquareClient, and exposes both the configuration array
+ * ($squareConfig) and client ($square).
+ */
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (!isset($config)) {
+    $configPath = __DIR__ . '/../config.php';
+    if (file_exists($configPath)) {
+        $config = require $configPath;
+    } else {
+        $config = [];
+    }
+}
+
+use Square\Environment;
+use Square\SquareClient;
+
+$squareConfig = [
+    'application_id' => $config['square_application_id'] ?? getenv('SQUARE_APPLICATION_ID') ?? '',
+    'location_id' => $config['square_location_id'] ?? getenv('SQUARE_LOCATION_ID') ?? '',
+    'access_token' => $config['square_access_token'] ?? getenv('SQUARE_ACCESS_TOKEN') ?? '',
+    'environment' => $config['square_environment'] ?? getenv('SQUARE_ENVIRONMENT') ?? 'sandbox',
+];
+
+$square = new SquareClient([
+    'accessToken' => $squareConfig['access_token'],
+    'environment' => $squareConfig['environment'] === 'production' ? Environment::PRODUCTION : Environment::SANDBOX,
+]);
+
+?>

--- a/schema/payments.sql
+++ b/schema/payments.sql
@@ -1,0 +1,13 @@
+-- SQL schema for recording payment transactions
+
+CREATE TABLE payments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    listing_id INT NOT NULL,
+    amount INT NOT NULL,
+    payment_id VARCHAR(100),
+    status VARCHAR(50),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (listing_id) REFERENCES listings(id)
+);


### PR DESCRIPTION
## Summary
- Load Square credentials and instantiate Square\SquareClient via a shared helper
- Use the Square SDK in checkout processing to charge tokens and log payments
- Adjust checkout page to pull IDs from the new helper config

## Testing
- `php -l includes/square.php`
- `php -l checkout_process.php`
- `php -l checkout.php`


------
https://chatgpt.com/codex/tasks/task_e_68b538e33ff8832ba7e5182655a5d2db