### PR TITLE
Add cart link and listing detail page

### DIFF
--- a/assets/cart.svg
+++ b/assets/cart.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="9" cy="21" r="1"/>
+  <circle cx="20" cy="21" r="1"/>
+  <path d="M1 1h4l2.68 13.39a2 2 0 002 1.61h9.72a2 2 0 002-1.64L23 6H6"/>
+</svg>

--- a/buy.php
+++ b/buy.php
@@ -113,7 +113,7 @@ $stmt->close();
         <div class="product-grid" id="product-container">
         <?php foreach ($listings as $l): ?>
           <div class="product-card">
-            <?php $link = isset($_SESSION['user_id']) ? "checkout.php?listing_id={$l['id']}" : 'login.php'; ?>
+            <?php $link = "listing.php?listing_id={$l['id']}"; ?>
             <a href="<?= $link ?>" class="listing-link">
               <?php if ($l['image']): ?>
                 <img src="uploads/<?= htmlspecialchars($l['image']) ?>" alt="">

--- a/includes/header.php
+++ b/includes/header.php
@@ -34,6 +34,7 @@ if (!empty($_SESSION['user_id'])) {
 
     $unread_notifications = count_unread_notifications($conn, $_SESSION['user_id']);
   }
+  $cart_count = isset($_SESSION['cart']) ? count($_SESSION['cart']) : 0;
 ?>
 <header class="site-header">
   <nav class="site-nav header-left">
@@ -61,6 +62,12 @@ if (!empty($_SESSION['user_id'])) {
       <li><a href="/logout.php">Logout</a></li>
       <li class="user-info"><?= username_with_avatar($conn, $_SESSION['user_id'], $username) ?></li>
 <?php endif; ?>
+      <li class="cart-link">
+        <a href="/checkout.php">
+          <img src="/assets/cart.svg" alt="Cart">
+          <?php if (!empty($cart_count)): ?><span class="badge"><?= $cart_count ?></span><?php endif; ?>
+        </a>
+      </li>
       <li><button id="theme-toggle" type="button" aria-haspopup="dialog" aria-controls="theme-modal">Themes</button></li>
     </ul>
   </nav>

--- a/includes/square.php
+++ b/includes/square.php
@@ -7,7 +7,7 @@
  * ($squareConfig) and client ($square).
  */
 
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 if (!isset($config)) {
     $configPath = __DIR__ . '/../config.php';
@@ -18,7 +18,6 @@ if (!isset($config)) {
     }
 }
 
-use Square\Environment;
 use Square\SquareClient;
 
 $squareConfig = [
@@ -30,7 +29,7 @@ $squareConfig = [
 
 $square = new SquareClient([
     'accessToken' => $squareConfig['access_token'],
-    'environment' => $squareConfig['environment'] === 'production' ? Environment::PRODUCTION : Environment::SANDBOX,
+    'environment' => $squareConfig['environment'],
 ]);
 
 ?>

--- a/listing.php
+++ b/listing.php
@@ -1,0 +1,42 @@
+<?php
+require 'includes/db.php';
+
+$listing_id = isset($_GET['listing_id']) ? intval($_GET['listing_id']) : 0;
+if (!$listing_id) {
+    header('Location: buy.php');
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT id, title, description, price, category, image FROM listings WHERE id = ? LIMIT 1');
+$stmt->bind_param('i', $listing_id);
+$stmt->execute();
+$result = $stmt->get_result();
+$listing = $result->fetch_assoc();
+$stmt->close();
+
+if (!$listing) {
+    http_response_code(404);
+    echo 'Listing not found';
+    exit;
+}
+?>
+<?php require 'includes/layout.php'; ?>
+  <meta charset="UTF-8">
+  <title><?= htmlspecialchars($listing['title']); ?></title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <div class="content listing-detail">
+    <h2><?= htmlspecialchars($listing['title']); ?></h2>
+    <?php if (!empty($listing['image'])): ?>
+      <img src="uploads/<?= htmlspecialchars($listing['image']); ?>" alt="<?= htmlspecialchars($listing['title']); ?>">
+    <?php endif; ?>
+    <p><?= nl2br(htmlspecialchars($listing['description'])); ?></p>
+    <p class="price">$<?= htmlspecialchars($listing['price']); ?></p>
+    <a class="btn" href="checkout.php?listing_id=<?= $listing['id']; ?>">Proceed to Checkout</a>
+  </div>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add cart icon with optional count to header navigation
- create listing detail page showing full listing information and checkout button
- update buy page to route listing links to new detail page
- simplify Square client initialization to accept string environment settings and use a root-relative autoloader

## Testing
- `php -l includes/header.php`
- `php -l listing.php`
- `php -l buy.php`
- `php -l includes/square.php`
- `php -r 'require "stub_square.php"; putenv("SQUARE_ENVIRONMENT=sandbox"); include "includes/square.php"; echo $squareConfig["environment"] . "\\n";'`
- `php -r 'require "stub_square.php"; putenv("SQUARE_ENVIRONMENT=production"); include "includes/square.php"; echo $squareConfig["environment"] . "\\n";'`


------
https://chatgpt.com/codex/tasks/task_e_68b54db4d500832b9075e699de3520d8