### PR TITLE
Add Square credentials config and helper integration

### DIFF
--- a/config.square.php
+++ b/config.square.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Square-specific configuration.
+ *
+ * This file provides the SQUARE_ACCESS_TOKEN constant required for
+ * communicating with Square's APIs and may optionally define SQUARE_ENV
+ * (e.g., 'production' or 'sandbox').
+ *
+ * Real credentials should not be committed to version control. Instead, set
+ * the relevant environment variables or edit this file locally without
+ * committing.
+ */
+
+if (!defined('SQUARE_ACCESS_TOKEN')) {
+    // Prefer an environment variable but fall back to a placeholder.
+    define('SQUARE_ACCESS_TOKEN', getenv('SQUARE_ACCESS_TOKEN') ?: 'YOUR_SQUARE_ACCESS_TOKEN');
+}
+
+// Optionally define SQUARE_ENV if provided via environment variable.
+if (!defined('SQUARE_ENV')) {
+    $env = getenv('SQUARE_ENV');
+    if ($env !== false && $env !== '') {
+        define('SQUARE_ENV', $env);
+    }
+}
+
+?>
+

--- a/includes/square.php
+++ b/includes/square.php
@@ -9,6 +9,13 @@
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
+// Load Square-specific credentials if present. This file may define
+// SQUARE_ACCESS_TOKEN and optionally SQUARE_ENV.
+$squareConfigPath = __DIR__ . '/../config.square.php';
+if (file_exists($squareConfigPath)) {
+    require $squareConfigPath;
+}
+
 if (!isset($config)) {
     $configPath = __DIR__ . '/../config.php';
     if (file_exists($configPath)) {
@@ -22,9 +29,13 @@ use Square\SquareClient;
 
 $squareConfig = [
     'application_id' => $config['square_application_id'] ?? getenv('SQUARE_APPLICATION_ID') ?? '',
-    'location_id' => $config['square_location_id'] ?? getenv('SQUARE_LOCATION_ID') ?? '',
-    'access_token' => $config['square_access_token'] ?? getenv('SQUARE_ACCESS_TOKEN') ?? '',
-    'environment' => $config['square_environment'] ?? getenv('SQUARE_ENVIRONMENT') ?? 'sandbox',
+    'location_id'   => $config['square_location_id'] ?? getenv('SQUARE_LOCATION_ID') ?? '',
+    'access_token'  => defined('SQUARE_ACCESS_TOKEN')
+        ? SQUARE_ACCESS_TOKEN
+        : ($config['square_access_token'] ?? getenv('SQUARE_ACCESS_TOKEN') ?? ''),
+    'environment'   => defined('SQUARE_ENV')
+        ? SQUARE_ENV
+        : ($config['square_environment'] ?? getenv('SQUARE_ENVIRONMENT') ?? 'sandbox'),
 ];
 
 $square = new SquareClient([


### PR DESCRIPTION
## Summary
- load Square credentials from new `config.square.php`
- support optional `SQUARE_ENV` override in Square helper

## Testing
- `php -l includes/square.php`
- `php -l config.square.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5551cc4c4832ba02ce2a052ad6cb5