### PR TITLE
Refactor Square client to use explicit base URL

### DIFF
--- a/includes/square.php
+++ b/includes/square.php
@@ -38,9 +38,13 @@ $squareConfig = [
         : ($config['square_environment'] ?? getenv('SQUARE_ENVIRONMENT') ?? 'sandbox'),
 ];
 
-$square = new SquareClient([
-    'accessToken' => $squareConfig['access_token'],
-    'environment' => $squareConfig['environment'],
-]);
+$square = new SquareClient(
+    token: $squareConfig['access_token'],
+    options: [
+        'baseUrl' => $squareConfig['environment'] === 'production'
+            ? 'https://connect.squareup.com'
+            : 'https://connect.squareupsandbox.com',
+    ],
+);
 
 ?>


### PR DESCRIPTION
## Summary
- instantiate `SquareClient` with token and explicit `baseUrl` derived from environment
- drop old constructor `environment` option

## Testing
- `php -l includes/square.php`
- `php -r "require 'includes/square.php'; echo 'loaded';"`
- `php checkout.php` *(fails: No such file or directory in db.php:23)*

------
https://chatgpt.com/codex/tasks/task_e_68b56eaf31a0832b8b35e5882f1dd978