### PR TITLE
Refactor header navigation and add sidebar translation

### DIFF
--- a/assets/sidebar.js
+++ b/assets/sidebar.js
@@ -3,7 +3,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const sideNav = document.querySelector('.side-nav');
   if (toggle && sideNav) {
     toggle.addEventListener('click', () => {
-      sideNav.classList.toggle('open');
+      sideNav.classList.add('open');
+      document.body.classList.toggle('nav-open');
     });
   }
 });

--- a/assets/style.css
+++ b/assets/style.css
@@ -16,6 +16,7 @@
   --pattern-sat: 100%;
   --btn-depth: 6px;
   --cta-depth: 20px;
+  --border: rgba(255, 255, 255, 0.2);
 }
 
 [data-theme='dark'] {
@@ -23,6 +24,7 @@
   --fg: #e0d9f6;
   --accent: #01cdfe;
   --gradient: linear-gradient(135deg, #2d1e59 0%, #09002e 100%);
+  --border: rgba(224, 217, 246, 0.3);
 }
 
 [data-theme='vaporwave'] {
@@ -30,6 +32,7 @@
   --fg: #ffffff;
   --accent: var(--vap1);
   --gradient: linear-gradient(-45deg, var(--vap1), var(--vap2), var(--vap3), var(--vap1));
+  --border: var(--accent);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -38,6 +41,7 @@
     --fg: #e0d9f6;
     --accent: #01cdfe;
     --gradient: linear-gradient(135deg, #2d1e59 0%, #09002e 100%);
+    --border: rgba(224, 217, 246, 0.3);
   }
 }
 
@@ -69,6 +73,19 @@ body {
   font-size: 0.85rem;
   margin: 0;
   padding: 1rem;
+  border: 2px solid var(--border);
+  --nav-shift: 0;
+  transform: translateX(var(--nav-shift));
+  transition: transform 0.3s ease;
+}
+
+a,
+a:visited {
+  color: var(--fg);
+}
+
+body.nav-open {
+  --nav-shift: 200px;
 }
 
 .vap-lines {
@@ -237,8 +254,8 @@ footer {
     inset 0 -2px 0 rgba(0, 0, 0, 0.5),
     0 -2px var(--footer-depth) rgba(0, 0, 0, 0.5),
     0 2px var(--footer-depth) rgba(255, 255, 255, 0.1);
-  transform: perspective(500px) translateZ(0);
-  transition: transform 0.2s, box-shadow 0.2s;
+  transform: perspective(500px) translateZ(0) translateX(var(--nav-shift));
+  transition: transform 0.3s, box-shadow 0.2s;
 }
 
 footer::before {
@@ -253,7 +270,8 @@ footer::before {
 }
 
 footer:hover {
-  transform: perspective(500px) translateZ(var(--footer-depth));
+  transform: perspective(500px) translateZ(var(--footer-depth))
+    translateX(var(--nav-shift));
   box-shadow: inset 0 2px 0 rgba(255, 255, 255, 0.2),
     inset 0 -2px 0 rgba(0, 0, 0, 0.5),
     0 -4px var(--footer-depth) rgba(0, 0, 0, 0.6),
@@ -365,8 +383,8 @@ footer:hover {
     0 2px var(--header-depth) rgba(0, 0, 0, 0.5),
     0 -2px var(--header-depth) rgba(255, 255, 255, 0.1);
   perspective: 500px;
-  transform: perspective(500px) translateZ(0);
-  transition: transform 0.2s, box-shadow 0.2s;
+  transform: perspective(500px) translateZ(0) translateX(var(--nav-shift));
+  transition: transform 0.3s, box-shadow 0.2s;
   text-transform: uppercase;
 }
 
@@ -382,7 +400,8 @@ footer:hover {
 }
 
 .site-header:hover {
-  transform: perspective(500px) translateZ(var(--header-depth));
+  transform: perspective(500px) translateZ(var(--header-depth))
+    translateX(var(--nav-shift));
   box-shadow: inset 0 2px 0 rgba(255, 255, 255, 0.2),
     inset 0 -2px 0 rgba(0, 0, 0, 0.5),
     0 4px var(--header-depth) rgba(0, 0, 0, 0.6),
@@ -393,8 +412,12 @@ footer:hover {
 .header-center,
 .header-right {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
+}
+
+.header-right {
+  justify-content: flex-end;
 }
 
 .header-left,
@@ -420,6 +443,36 @@ footer:hover {
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.header-right ul {
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-columns: repeat(4, auto);
+  align-items: center;
+  justify-content: end;
+}
+
+.header-right li {
+  display: flex;
+  align-items: center;
+}
+
+header .header-right button,
+header .header-right select,
+header .header-right a {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  padding: 0.25rem 0.5rem;
+  border-radius: 3px;
+  text-decoration: none;
+  box-shadow: none;
+}
+
+header .header-right a {
+  display: inline-flex;
+  align-items: center;
 }
 
 .site-nav a {
@@ -461,6 +514,7 @@ footer:hover {
 
   .header-left ul,
   .header-right ul {
+    display: flex;
     flex-wrap: wrap;
     justify-content: center;
   }
@@ -618,14 +672,19 @@ td {
 th {
   background: var(--accent);
   color: #fff;
+  font-weight: 600;
+}
+
+table a {
+  color: var(--fg);
 }
 
 tbody tr:nth-child(even) {
-  background: rgba(0, 0, 0, 0.05);
+  background: rgba(0, 0, 0, 0.08);
 }
 
 [data-theme='dark'] tbody tr:nth-child(even) {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 /* Drag and drop upload */
@@ -908,7 +967,17 @@ tbody tr:nth-child(even) {
 }
 
 .message {
-  margin-bottom: 0.5rem;
+  max-width: 60%;
+  margin: 0 0 0.5rem;
+}
+
+.message-left {
+  margin-right: auto;
+}
+
+.message-center {
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .message-form textarea {

--- a/assets/style.css
+++ b/assets/style.css
@@ -448,7 +448,7 @@ footer:hover {
 .header-right ul {
   display: grid;
   grid-auto-flow: column;
-  grid-template-columns: repeat(4, auto);
+  grid-auto-columns: auto;
   align-items: center;
   justify-content: end;
 }
@@ -460,7 +460,8 @@ footer:hover {
 
 header .header-right button,
 header .header-right select,
-header .header-right a {
+header .header-right .user-info,
+header .header-right .cart-link a {
   background: var(--bg);
   border: 1px solid var(--border);
   color: var(--fg);
@@ -470,7 +471,8 @@ header .header-right a {
   box-shadow: none;
 }
 
-header .header-right a {
+header .header-right .user-info,
+header .header-right .cart-link a {
   display: inline-flex;
   align-items: center;
 }

--- a/assets/themes.json
+++ b/assets/themes.json
@@ -5,7 +5,8 @@
       "--bg": "#2d1e59",
       "--fg": "#f8f9fa",
       "--accent": "#ff71ce",
-      "--gradient": "linear-gradient(135deg, #ff71ce 0%, #01cdfe 100%)"
+      "--gradient": "linear-gradient(135deg, #ff71ce 0%, #01cdfe 100%)",
+      "--border": "rgba(255, 255, 255, 0.2)"
     }
   },
   "dark": {
@@ -14,7 +15,8 @@
       "--bg": "#1b1135",
       "--fg": "#e0d9f6",
       "--accent": "#01cdfe",
-      "--gradient": "linear-gradient(135deg, #2d1e59 0%, #09002e 100%)"
+      "--gradient": "linear-gradient(135deg, #2d1e59 0%, #09002e 100%)",
+      "--border": "rgba(224, 217, 246, 0.3)"
     }
   },
   "vaporwave": {
@@ -26,12 +28,15 @@
       "--gradient": "linear-gradient(-45deg, var(--vap1), var(--vap2), var(--vap3), var(--vap1))",
       "--vap1": "#ff71ce",
       "--vap2": "#01cdfe",
-      "--vap3": "#05ffa1"
+      "--vap3": "#05ffa1",
+      "--border": "var(--accent)"
     },
     "pattern": {
       "frequency": 5,
       "amplitude": 20,
-      "poly": [0],
+      "poly": [
+        0
+      ],
       "hue": 0,
       "sat": 100
     }
@@ -42,7 +47,8 @@
       "--bg": "#ffe4e1",
       "--fg": "#333333",
       "--accent": "#ffb6c1",
-      "--gradient": "linear-gradient(135deg, #ffe4e1 0%, #e0ffff 100%)"
+      "--gradient": "linear-gradient(135deg, #ffe4e1 0%, #e0ffff 100%)",
+      "--border": "#333333"
     }
   },
   "forest": {
@@ -51,7 +57,8 @@
       "--bg": "#2e3d2f",
       "--fg": "#e6e8e6",
       "--accent": "#4caf50",
-      "--gradient": "linear-gradient(135deg, #2e3d2f 0%, #1b2c20 100%)"
+      "--gradient": "linear-gradient(135deg, #2e3d2f 0%, #1b2c20 100%)",
+      "--border": "var(--accent)"
     }
   }
 }

--- a/includes/header.php
+++ b/includes/header.php
@@ -59,14 +59,16 @@ if (!empty($_SESSION['user_id'])) {
           <option value="es">ES</option>
         </select>
       </li>
-      <li class="user-info">
 <?php if (empty($_SESSION['user_id'])): ?>
-        <a href="/login.php">Login</a> /
-        <a href="/register.php">Register</a>
+      <li><a href="/login.php">Login</a></li>
+      <li><a href="/register.php">Register</a></li>
 <?php else: ?>
-        <?= username_with_avatar($conn, $_SESSION['user_id'], $username) ?>
+      <li><a href="/dashboard.php">Dashboard</a></li>
+      <li><a href="/notifications.php">Notifications<?php if (!empty($unread_notifications)): ?><span class="badge"><?= $unread_notifications ?></span><?php endif; ?></a></li>
+      <li><a href="/messages.php">Messages<?php if (!empty($unread_messages)): ?><span class="badge"><?= $unread_messages ?></span><?php endif; ?></a></li>
+      <li><a href="/logout.php">Logout</a></li>
+      <li class="user-info"><?= username_with_avatar($conn, $_SESSION['user_id'], $username) ?></li>
 <?php endif; ?>
-      </li>
       <li class="cart-link">
         <a href="/checkout.php">
           <img src="/assets/cart.svg" alt="Cart">

--- a/includes/header.php
+++ b/includes/header.php
@@ -52,23 +52,27 @@ if (!empty($_SESSION['user_id'])) {
   </form>
   <nav class="site-nav header-right">
     <ul>
+      <li><button id="theme-toggle" type="button" aria-haspopup="dialog" aria-controls="theme-modal">Themes</button></li>
+      <li class="language-selector">
+        <select id="language-select" name="language">
+          <option value="en">EN</option>
+          <option value="es">ES</option>
+        </select>
+      </li>
+      <li class="user-info">
 <?php if (empty($_SESSION['user_id'])): ?>
-      <li><a href="/login.php">Login</a></li>
-      <li><a href="/register.php">Register</a></li>
+        <a href="/login.php">Login</a> /
+        <a href="/register.php">Register</a>
 <?php else: ?>
-      <li><a href="/dashboard.php">Dashboard</a></li>
-      <li><a href="/notifications.php">Notifications<?php if (!empty($unread_notifications)): ?><span class="badge"><?= $unread_notifications ?></span><?php endif; ?></a></li>
-      <li><a href="/messages.php">Messages<?php if (!empty($unread_messages)): ?><span class="badge"><?= $unread_messages ?></span><?php endif; ?></a></li>
-      <li><a href="/logout.php">Logout</a></li>
-      <li class="user-info"><?= username_with_avatar($conn, $_SESSION['user_id'], $username) ?></li>
+        <?= username_with_avatar($conn, $_SESSION['user_id'], $username) ?>
 <?php endif; ?>
+      </li>
       <li class="cart-link">
         <a href="/checkout.php">
           <img src="/assets/cart.svg" alt="Cart">
           <?php if (!empty($cart_count)): ?><span class="badge"><?= $cart_count ?></span><?php endif; ?>
         </a>
       </li>
-      <li><button id="theme-toggle" type="button" aria-haspopup="dialog" aria-controls="theme-modal">Themes</button></li>
     </ul>
   </nav>
 </header>

--- a/message-thread.php
+++ b/message-thread.php
@@ -58,7 +58,7 @@ $stmt->close();
   <h2>Conversation with <?= htmlspecialchars($other_username) ?></h2>
   <div class="message-thread">
     <?php foreach ($messages as $msg): ?>
-      <div class="message">
+      <div class="message message-left">
         <strong><?= htmlspecialchars($msg['sender_name']) ?>:</strong>
         <span><?= nl2br(htmlspecialchars($msg['body'])) ?></span>
         <em><?= htmlspecialchars($msg['created_at']) ?></em>


### PR DESCRIPTION
## Summary
- reorganize header-right markup to include theme toggle, language select, user info, and cart
- implement grid layout for header-right links and right-align group
- toggle `nav-open` on body so content shifts right while sidebar remains open
- translate body, site-header, and footer with smooth transition when nav is open
- set high-contrast default link color and refine table typography
- define default border variable with body border and theme overrides
- give header utilities contrasting backgrounds and borders for clarity
- limit message bubble width and add left/center alignment styles for threads

## Testing
- `php -l message-thread.php`
- `php -l includes/header.php`
- `node --check assets/sidebar.js`
- `npx --yes stylelint assets/style.css`
- `jq empty assets/themes.json`


------
https://chatgpt.com/codex/tasks/task_e_68b9f5468e50832bb4ab18796db6fac8